### PR TITLE
Handle unpublish call with empty node ID correctly

### DIFF
--- a/src/driver/controller.go
+++ b/src/driver/controller.go
@@ -176,9 +176,6 @@ func (s *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	if req.VolumeId == "" {
 		return nil, status.Error(codes.InvalidArgument, "invalid volume id")
 	}
-	if req.NodeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "invalid node id")
-	}
 
 	volumeID, err := parseVolumeID(req.VolumeId)
 	if err != nil {
@@ -186,11 +183,14 @@ func (s *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 	volume := &csi.Volume{ID: volumeID}
 
-	serverID, err := parseNodeID(req.NodeId)
-	if err != nil {
-		return nil, status.Error(codes.NotFound, "node not found")
+	var server *csi.Server
+	if req.NodeId != "" {
+		serverID, err := parseNodeID(req.NodeId)
+		if err != nil {
+			return nil, status.Error(codes.NotFound, "node not found")
+		}
+		server = &csi.Server{ID: serverID}
 	}
-	server := &csi.Server{ID: serverID}
 
 	if err := s.volumeService.Detach(ctx, volume, server); err != nil {
 		code := codes.Internal

--- a/src/driver/controller_test.go
+++ b/src/driver/controller_test.go
@@ -606,6 +606,26 @@ func TestControllerServiceUnpublishVolume(t *testing.T) {
 	}
 }
 
+func TestControllerServiceUnpublishVolumeNoNode(t *testing.T) {
+	env := newControllerServiceTestEnv()
+
+	env.volumeService.DetachFunc = func(ctx context.Context, volume *csi.Volume, server *csi.Server) error {
+		if server != nil {
+			t.Errorf("unexpected server id passed to volume service: %d", server.ID)
+		}
+		return nil
+	}
+
+	req := &proto.ControllerUnpublishVolumeRequest{
+		VolumeId: "1",
+		NodeId:   "",
+	}
+	_, err := env.service.ControllerUnpublishVolume(env.ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestControllerServiceUnpublishVolumeInputErrors(t *testing.T) {
 	env := newControllerServiceTestEnv()
 
@@ -623,14 +643,6 @@ func TestControllerServiceUnpublishVolumeInputErrors(t *testing.T) {
 			Req: &proto.ControllerUnpublishVolumeRequest{
 				VolumeId: "",
 				NodeId:   "2",
-			},
-			Code: codes.InvalidArgument,
-		},
-		{
-			Name: "empty node id",
-			Req: &proto.ControllerUnpublishVolumeRequest{
-				VolumeId: "1",
-				NodeId:   "",
 			},
 			Code: codes.InvalidArgument,
 		},


### PR DESCRIPTION
From the spec:

  // The ID of the node. This field is OPTIONAL. The CO SHOULD set this
  // field to match the node ID returned by `NodeGetInfo` or leave it
  // unset. If the value is set, the SP MUST unpublish the volume from
  // the specified node. If the value is unset, the SP MUST unpublish
  // the volume from all nodes it is published to.
  string node_id = 2;

Fixes #13.