### PR TITLE
UnpublishVolume: Return ErrAlreadyAttached

### DIFF
--- a/src/volumes/idempotency.go
+++ b/src/volumes/idempotency.go
@@ -134,9 +134,6 @@ func (s *IdempotentService) Detach(ctx context.Context, volume *csi.Volume, serv
 	switch err := s.volumeService.Detach(ctx, volume, server); err {
 	case ErrNotAttached:
 		return nil
-	case ErrAlreadyAttached:
-		// Volume is attached to another server
-		return nil
 	case nil:
 		return nil
 	default:

--- a/src/volumes/idempotency_test.go
+++ b/src/volumes/idempotency_test.go
@@ -311,7 +311,7 @@ func TestIdempotentServiceDetachAttachedToDifferentServer(t *testing.T) {
 	service := volumes.NewIdempotentService(log.NewNopLogger(), volumeService)
 
 	err := service.Detach(context.Background(), &csi.Volume{}, &csi.Server{})
-	if err != nil {
+	if err == nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
I am fairly certain this is the cause for #12. I have deployed an adjusted version of the CSI driver that has this patch and some tests running on the side that created/deleted ~150PVCs, not a single dangling volume whereas on Friday we had those again, with a lot less PVCs created/deleted.

Fixes #12 