### PR TITLE
Install xfsprogs into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ADD src /csi/src/
 RUN CGO_ENABLED=0 go build -o driver.bin hetzner.cloud/csi/cmd/driver
 
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates e2fsprogs
+RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs
 COPY --from=builder /csi/src/driver.bin /bin/hcloud-csi-driver
 ENTRYPOINT ["/bin/hcloud-csi-driver"]


### PR DESCRIPTION
Currently, XFS volume creation fails with an error:
```
May 29 00:32:51 dockerd-current[14528]: E0528 21:32:51.575423       1 mount_linux.go:495] format of disk "/dev/disk/by-id/scsi-0HC_Volume_26xxxxx" failed: type:("xfs") target:("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-c711522b
May 29 00:32:51 kubelet[15598]: E0529 00:32:51.576309   15598 csi_attacher.go:320] kubernetes.io/csi: attacher.MountDevice failed: rpc error: code = Internal desc = failed to stage volume: executable file not found in $PATH
```
Installing xfsprogs into hcloud-csi-driver container fixes this problem.