### PR TITLE
update deployment for k8s 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ enabling you to use Volumes within Kubernetes. Please note that this driver **re
 
 ## Getting Started
 
-1. If running kubernetes < 1.14:
+1. If running Kubernetes < 1.14:
 
    1. Make sure that the following [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
       are enabled in your cluster (kubelet and kube-apiserver):
@@ -26,6 +26,7 @@ enabling you to use Volumes within Kubernetes. Please note that this driver **re
 2. Create an API token in the [Hetzner Cloud Console](https://console.hetzner.cloud/).
 
 3. Create a secret containing the token:
+
    ```
    apiVersion: v1
    kind: Secret
@@ -41,7 +42,9 @@ enabling you to use Volumes within Kubernetes. Please note that this driver **re
    ```
    kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/master/deploy/kubernetes/hcloud-csi.yml
    ```
-   Or, if using kubernetes < 1.14:
+
+   Or, if using Kubernetes < 1.14:
+
    ```
    kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/master/deploy/kubernetes/hcloud-csi-1.13.yml
    ```

--- a/README.md
+++ b/README.md
@@ -7,32 +7,25 @@ enabling you to use Volumes within Kubernetes. Please note that this driver **re
 
 ## Getting Started
 
-1. Make sure that the following [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
-   are enabled in your cluster (kubelet and kube-apiserver):
+1. If running kubernetes < 1.14:
 
-   ```
-   --feature-gates=CSINodeInfo=true,CSIDriverRegistry=true
-   ```
+   1. Make sure that the following [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+      are enabled in your cluster (kubelet and kube-apiserver):
+      ```
+      --feature-gates=CSINodeInfo=true,CSIDriverRegistry=true
+      ```
 
-   These feature gates are enabled by default in Kubernetes 1.14 and later.
+   2. Create the custom resources `CSINodeInfo` and `CSIDriver` as described in the
+      [CSI objects section in the Kubernetes CSI documentation](https://kubernetes-csi.github.io/docs/csi-objects.html):
 
-2. Create the custom resources `CSINodeInfo` and `CSIDriver` as described in the
-   [CSI objects section in the Kubernetes CSI documentation](https://kubernetes-csi.github.io/docs/csi-objects.html):
+      ```
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csidriver.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csinodeinfo.yaml
+      ```
 
-   ```
-   kubectl apply -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csidriver.yaml
-   kubectl apply -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csinodeinfo.yaml
-   ```
+2. Create an API token in the [Hetzner Cloud Console](https://console.hetzner.cloud/).
 
-   For Kubernetes 1.14 and later the CSI CRDs are no longer needed so you can skip
-   this step (see [Enabling CSIDriver on Kubernetes](https://kubernetes-csi.github.io/docs/csi-driver-object.html#enabling-csidriver-on-kubernetes)).
-   Also, the `CSINodeInfo` object was renamed to `CSINode` in Kubernetes 1.14 as part
-   of the promotion from alpha to beta (see [CSINode Object](https://kubernetes-csi.github.io/docs/csi-node-object.html#changes-from-alpha-to-beta)).
-
-3. Create an API token in the [Hetzner Cloud Console](https://console.hetzner.cloud/).
-
-4. Create a secret containing the token:
-
+3. Create a secret containing the token:
    ```
    apiVersion: v1
    kind: Secret
@@ -43,13 +36,17 @@ enabling you to use Volumes within Kubernetes. Please note that this driver **re
      token: YOURTOKEN
    ```
 
-5. Deploy the CSI driver and wait until everything is up and running:
+4. Deploy the CSI driver and wait until everything is up and running:
 
    ```
    kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/master/deploy/kubernetes/hcloud-csi.yml
    ```
+   Or, if using kubernetes < 1.14:
+   ```
+   kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/master/deploy/kubernetes/hcloud-csi-1.13.yml
+   ```
 
-6. To verify everything is working, create a persistent volume claim and a pod
+5. To verify everything is working, create a persistent volume claim and a pod
    which uses that volume:
 
    ```

--- a/deploy/kubernetes/hcloud-csi-1.13.yml
+++ b/deploy/kubernetes/hcloud-csi-1.13.yml
@@ -1,12 +1,4 @@
 ---
-apiVersion: storage.k8s.io/v1beta1
-kind: CSIDriver
-metadata:
-  name: csi.hetzner.cloud
-spec:
-  attachRequired: true
-  podInfoOnMount: true
----
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -35,8 +27,8 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
@@ -63,6 +55,13 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+  # cluster registrar
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "list", "watch", "delete"]
   # node
   - apiGroups: [""]
     resources: ["events"]
@@ -100,7 +99,7 @@ spec:
       serviceAccount: hcloud-csi
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.1
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
             - --v=5
@@ -113,7 +112,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.2.1
+          image: quay.io/k8scsi/csi-provisioner:v1.0.1
           args:
             - --provisioner=csi.hetzner.cloud
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -127,6 +126,15 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
+        - name: csi-cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          args:
+            - --pod-info-mount-version="v1"
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: hcloud-csi-driver
           image: hetznercloud/hcloud-csi-driver:1.1.4
           imagePullPolicy: Always
@@ -170,7 +178,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
- cluster-driver-registrar is no longer needed, instead being replaced
by manual declaration of the CSIDriver CRD.
- CSI sidecar images updated
- small README refactoring to account for version compatibilities

fixes #42