### PR TITLE
Allow retry on attach/detach when server is locked

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,25 +1,29 @@
 # Changes
 
+## master
+
+- Revert fix from v1.1.2 to retry attach/detach when server is locked
+
 ## v1.1.4
 
-* Respect minimum volume size of 10 GB
+- Respect minimum volume size of 10 GB
 
 ## v1.1.3
 
-* Detach volumes before deleting them
+- Detach volumes before deleting them
 
 ## v1.1.2
 
-* Fix error handling for attaching/detaching volumes in case server is locked
+- Fix error handling for attaching/detaching volumes in case server is locked
 
 ## v1.1.1
 
-* Improve logging
+- Improve logging
 
 ## v1.1.0
 
-* Implement topology awareness (supporting nodes and volumes in different locations)
+- Implement topology awareness (supporting nodes and volumes in different locations)
 
 ## v1.0.0
 
-* Initial release
+- Initial release

--- a/src/api/volume.go
+++ b/src/api/volume.go
@@ -202,6 +202,9 @@ func (s *VolumeService) Attach(ctx context.Context, volume *csi.Volume, server *
 		if hcloud.IsError(err, hcloud.ErrorCode("limit_exceeded_error")) {
 			return volumes.ErrAttachLimitReached
 		}
+		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+			return volumes.ErrLockedServer
+		}
 		return err
 	}
 
@@ -276,6 +279,9 @@ func (s *VolumeService) Detach(ctx context.Context, volume *csi.Volume, server *
 			"volume-id", volume.ID,
 			"err", err,
 		)
+		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+			return volumes.ErrLockedServer
+		}
 		return err
 	}
 

--- a/src/driver/controller.go
+++ b/src/driver/controller.go
@@ -163,6 +163,8 @@ func (s *ControllerService) ControllerPublishVolume(ctx context.Context, req *pr
 			code = codes.FailedPrecondition
 		case volumes.ErrAttachLimitReached:
 			code = codes.ResourceExhausted
+		case volumes.ErrLockedServer:
+			code = codes.Aborted
 		}
 		return nil, status.Error(code, fmt.Sprintf("failed to publish volume: %s", err))
 	}
@@ -198,6 +200,8 @@ func (s *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 			code = codes.NotFound
 		case volumes.ErrServerNotFound:
 			code = codes.NotFound
+		case volumes.ErrLockedServer:
+			code = codes.Aborted
 		}
 		return nil, status.Error(code, fmt.Sprintf("failed to unpublish volume: %s", err))
 	}

--- a/src/driver/controller_test.go
+++ b/src/driver/controller_test.go
@@ -555,6 +555,11 @@ func TestControllerServicePublishVolumeAttachErrors(t *testing.T) {
 			AttachError: volumes.ErrAttachLimitReached,
 			Code:        codes.ResourceExhausted,
 		},
+		{
+			Name:        "aborted",
+			AttachError: volumes.ErrLockedServer,
+			Code:        codes.Aborted,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -686,6 +691,11 @@ func TestControllerServiceUnpublishVolumeDetachErrors(t *testing.T) {
 			Name:        "server not found",
 			DetachError: volumes.ErrServerNotFound,
 			Code:        codes.NotFound,
+		},
+		{
+			Name:        "aborted",
+			DetachError: volumes.ErrLockedServer,
+			Code:        codes.Aborted,
 		},
 	}
 

--- a/src/volumes/service.go
+++ b/src/volumes/service.go
@@ -14,6 +14,7 @@ var (
 	ErrAttached            = errors.New("volume is attached")
 	ErrNotAttached         = errors.New("volume is not attached")
 	ErrAttachLimitReached  = errors.New("max number of attachments per server reached")
+	ErrLockedServer        = errors.New("server is locked")
 )
 
 type Service interface {


### PR DESCRIPTION
I'm currently running 1.1.4 on Kubernetes 1.14.4 and noticed that occasionally when I drain a node the pods failed to be restarted on the new node with errors like:

> AttachVolume.Attach failed for volume "pvc-9cd8dc0d-be90-11e9-929a-9600001f93a6" : rpc error: code = Internal desc = failed to publish volume: cannot perform operation because server is locked (locked)

> AttachVolume.Attach failed for volume "pvc-9cd8dc0d-be90-11e9-929a-9600001f93a6" : rpc error: code = Internal desc = failed to publish volume: volume is already attached to a server, please detach it first (service_error)

Hetzner Cloud Console showed the volume still being attached to the drained node and I had to manually detach the volume from the server to resolve the issue.

According to the logs, the volume seems to be wrongfully marked as detached by the `csi-attacher`:

```
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:52.845893       1 connection.go:180] GRPC call: /csi.v1.Controller/ControllerUnpublishVolume
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:52.845921       1 connection.go:181] GRPC request: {"node_id":"2137023","volume_id":"2342411"}
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877373       1 controller.go:175] Started VA processing "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877457       1 csi_handler.go:87] CSIHandler: processing VA "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 hcloud-csi-driver] level=debug ts=2019-08-16T00:25:53.879912292Z component=grpc-server msg="handling request" req="volume_id:\"3078784\" node_id:\"2137023\" "
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877472       1 csi_handler.go:138] Starting detach operation for "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 hcloud-csi-driver] level=info ts=2019-08-16T00:25:53.879970775Z component=api-volume-service msg="detaching volume from server" volume-id=3078784 server-id=2137023
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877605       1 csi_handler.go:145] Detaching "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877636       1 csi_handler.go:509] Found NodeID 2137023 in CSINode w1
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877699       1 connection.go:180] GRPC call: /csi.v1.Controller/ControllerUnpublishVolume
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.877719       1 connection.go:181] GRPC request: {"node_id":"2137023","volume_id":"3078784"}
[hcloud-csi-controller-0 hcloud-csi-driver] level=info ts=2019-08-16T00:25:53.979714822Z component=api-volume-service msg="failed to detach volume" volume-id=3078784 err="cannot perform operation because server is locked (locked)"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.981599       1 connection.go:183] GRPC response: {}
[hcloud-csi-controller-0 hcloud-csi-driver] level=error ts=2019-08-16T00:25:53.980293364Z component=grpc-server msg="handler failed" err="rpc error: code = Internal desc = failed to unpublish volume: cannot perform operation because server is locked (locked)"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.984803       1 connection.go:184] GRPC error: rpc error: code = Internal desc = failed to unpublish volume: cannot perform operation because server is locked (locked)
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.984937       1 csi_handler.go:369] Detached "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf" with error rpc error: code = Internal desc = failed to unpublish volume: cannot perform operation because server is locked (locked)
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:53.985070       1 util.go:70] Marking as detached "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:54.015876       1 controller.go:205] Started PV processing "pvc-9cd8dc0d-be90-11e9-929a-9600001f93a6"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:54.016198       1 csi_handler.go:412] CSIHandler: processing PV "pvc-9cd8dc0d-be90-11e9-929a-9600001f93a6"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:54.016289       1 csi_handler.go:416] CSIHandler: processing PV "pvc-9cd8dc0d-be90-11e9-929a-9600001f93a6": no deletion timestamp, ignoring
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:54.017138       1 util.go:81] Finalizer removed from "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:54.017182       1 csi_handler.go:158] Fully detached "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:54.017198       1 csi_handler.go:103] CSIHandler: finished processing "csi-9c922a6ded15ca7a23d4c9d59b6915e34810f0f6e246c674e9e0c1c52773f3bf"
```

Because of that, the volume can't be attached to the new node:

```
hcloud-csi-controller-0 hcloud-csi-driver] level=debug ts=2019-08-16T00:25:55.813227275Z component=grpc-server msg="handling request" req="volume_id:\"2342411\" node_id:\"2488889\" volume_capability:<mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > > volume_context:<key:\"storage.kubernetes.io/csiProvisionerIdentity\" value:\"1554762700426-8081-csi.hetzner.cloud\" > "
[hcloud-csi-controller-0 hcloud-csi-driver] level=info ts=2019-08-16T00:25:55.81332145Z component=api-volume-service msg="attaching volume" volume-id=2342411 server-id=2488889
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.809852       1 csi_handler.go:199] VolumeAttachment "csi-74b5f5760bac20f4be794a66ba77fe5413a98633a162f9ea1cd9d4ae196c057d" updated with finalizer and/or NodeID annotation
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.809917       1 connection.go:180] GRPC call: /csi.v1.Controller/ControllerPublishVolume
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.809926       1 connection.go:181] GRPC request: {"node_id":"2488889","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}},"volume_context":{"storage.kubernetes.io/csiProvisionerIdentity":"1554762700426-8081-csi.hetzner.cloud"},"volume_id":"2342411"}
[hcloud-csi-controller-0 hcloud-csi-driver] level=info ts=2019-08-16T00:25:55.927389144Z component=api-volume-service msg="failed to attach volume" volume-id=3078784 server-id=2488889 err="volume is already attached to a server, please detach it first (service_error)"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.966681       1 connection.go:183] GRPC response: {}
[hcloud-csi-controller-0 hcloud-csi-driver] level=error ts=2019-08-16T00:25:55.96624625Z component=grpc-server msg="handler failed" err="rpc error: code = Internal desc = failed to publish volume: volume is already attached to a server, please detach it first (service_error)"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.967650       1 connection.go:184] GRPC error: rpc error: code = Internal desc = failed to publish volume: volume is already attached to a server, please detach it first (service_error)
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.967674       1 csi_handler.go:382] Saving attach error to "csi-4ba0fa72efd953e4036835f65ea92070fd99a7c78c4f560a065d4e09b9179c7b"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.979556       1 csi_handler.go:392] Saved attach error to "csi-4ba0fa72efd953e4036835f65ea92070fd99a7c78c4f560a065d4e09b9179c7b"
[hcloud-csi-controller-0 csi-attacher] I0816 00:25:55.979627       1 csi_handler.go:97] Error processing "csi-4ba0fa72efd953e4036835f65ea92070fd99a7c78c4f560a065d4e09b9179c7b": failed to attach: rpc error: code = Internal desc = failed to publish volume: volume is already attached to a server, please detach it first (service_error)
```

It look like this issue has been introduced in #19 and might only happen if the node has *multiple* volumes attached. When comparing with other CSI implementations the driver should indeed return `codes.Aborted` in case of this error:

- https://github.com/digitalocean/csi-digitalocean/blob/b6f04bdf41432cfee33de163b2515a75e7d747d4/driver/controller.go#L416-L424
- https://github.com/digitalocean/csi-digitalocean/blob/b6f04bdf41432cfee33de163b2515a75e7d747d4/driver/controller.go#L337-L345

And according to the spec:

> Recovery behaviour for `ABORTED`: Caller SHOULD ensure that there are no other calls pending for the specified volume, and then retry with exponential back off.

After deploying the changes of this PR ([`hwuethrich/hcloud-csi-driver:1.1.4-abort`](https://hub.docker.com/r/hwuethrich/hcloud-csi-driver)), the `csi-attacher` retries to detach the volume in case of this error and pods can be moved without errors.

This PR might also be related to #41 and #12.

### Side Note

While investigating this problem I also noticed I had some old `volumeattachments` referencing volumes which didn't exist anymore and some duplicates (multiple `volumeattachments` referencing the same volume). I deleted these manually, but I'm not sure if this is related to this issue (or maybe even expected?).

I used [jq](https://stedolan.github.io/jq/) and [xsv](https://github.com/BurntSushi/xsv) to get a list of `volumeattachments` and referenced volumes (in case this helps anyone):

```bash
$ kubectl get volumeattachments.storage.k8s.io -o json | jq -r ' .items | map({ name: .metadata.name, creationTimestamp: .metadata.creationTimestamp, node: .spec.nodeName, pvc: .spec.source.persistentVolumeName, attached: .status.attached }) | sort_by(.pvc) | (map(keys) | add | unique) as $cols | map(. as $row | $cols | map($row[.])) as $rows | $cols, $rows[] | @csv ' | xsv table

attached  creationTimestamp     name                                                                  node  pvc
true      2019-08-15T10:21:56Z  csi-37e72b5f0ba15a9301357f8dadff1710e0ea8377c3949df7d257c53cc85695f4  w6    pvc-000b9b3e-6cad-11e9-aba6-9600001f93a6
true      2019-07-21T21:20:08Z  csi-b74fdd2eede99245527be261d7f6e02815cbf552074c2d265a7680fa1a6d6d3a  w6    pvc-0b0b8a99-5a57-11e9-8814-9600001f93a6
true      2019-08-15T16:32:52Z  csi-0d9efdd9fbde13e5089b03991040d508fa0dbb3b35a0143def117039db45b31a  w2    pvc-12dc709e-5a57-11e9-8814-9600001f93a6
true      2019-08-15T15:29:37Z  csi-7a4d7affff2202938eb96c579ec15be9e5990eff7396d0da06d2440e4bcbc54a  w2    pvc-414f4b15-8927-11e9-a762-960000201058
true      2019-08-16T00:25:55Z  csi-74b5f5760bac20f4be794a66ba77fe5413a98633a162f9ea1cd9d4ae196c057d  w5    pvc-5679b1cd-5adb-11e9-8814-9600001f93a6
true      2019-08-15T20:11:00Z  csi-2b8faf9ab8dbdc9736e29e72c3872b8ef50434a99a9d368cab2b8390cccb4e4c  w3    pvc-567dad48-5adb-11e9-8814-9600001f93a6
true      2019-08-02T22:11:23Z  csi-acf403ec7fdb18607d94c0f0e03d7079876b9d27b2a0cd3e9c30a4bda3110798  w6    pvc-56810b67-5adb-11e9-8814-9600001f93a6
true      2019-08-16T00:26:24Z  csi-a1ab2190ba68080f47ef16708c32a80c8e5a14c271b68c98ff6e0090681cccce  w5    pvc-5ace90e4-49e7-11e9-bf94-9600001f93a5
true      2019-08-15T20:11:04Z  csi-d6ce7ed02712f25d8d9cd7b81a86ed419e7d62873af86388422e7680bc60befa  w3    pvc-88e2c276-61c8-11e9-8ac9-960000201071
false     2019-08-16T00:25:54Z  csi-4ba0fa72efd953e4036835f65ea92070fd99a7c78c4f560a065d4e09b9179c7b  w5    pvc-9cd8dc0d-be90-11e9-929a-9600001f93a6
true      2019-08-15T10:28:08Z  csi-a190c34ed0c8eaa74d78fd0f95bef88ac3ff0d39227bcda69bc9bf1e61586315  w6    pvc-bbdc8112-6c57-11e9-aba6-9600001f93a6
true      2019-08-15T16:32:27Z  csi-ca9cb490eae9f8e3c2ae832421f18d281070ed336d4cf7f121b4bf47a13ac13d  w2    pvc-bbe5bbdc-6c57-11e9-aba6-9600001f93a6
true      2019-08-16T00:26:54Z  csi-273c80ecda12ad9b7051a0b922711190b9502b07f2e60ed467b3685b3af6ab07  w5    pvc-bd81d1c5-6cac-11e9-aba6-9600001f93a6
true      2019-08-15T20:10:55Z  csi-c8ca37fd0b1e97449a6b804b8f711050577e19ba5d3c14a6529b6e43655d035d  w3    pvc-bd880b72-6cac-11e9-aba6-9600001f93a6
true      2019-08-15T16:32:34Z  csi-ad86f2c918b0f4d27fb6b06ab63755ec93c11bc0cbfea33ce320de7d8d7d0a66  w2    pvc-cce1d82c-b56e-11e9-929a-9600001f93a6
true      2019-08-16T00:26:00Z  csi-7d288a9731431c1347ca1cd78a9189367456832215a5fe6205ec88ae4d9890fe  w5    pvc-de244bf2-b1fc-11e9-929a-9600001f93a6
true      2019-07-29T12:32:06Z  csi-d1cfc2bddc14eda4044e0325c8526d2b9ea5473a307835bcc8d4c1eb8ec955a1  w6    pvc-de297005-b1fc-11e9-929a-9600001f93a6
true      2019-08-16T00:25:58Z  csi-95d2e5b3076b5c5282456c5afc95f54b3beeb28495ae6a342f1fec135331bac6  w5    pvc-ed34cc78-61e1-11e9-8ac9-960000201071
```
