### PR TITLE
Use released version v1.1.5 in the hcloud-cs-1.13 deployment manifest

### DIFF
--- a/deploy/kubernetes/hcloud-csi-1.13.yml
+++ b/deploy/kubernetes/hcloud-csi-1.13.yml
@@ -136,7 +136,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.1.4
+          image: hetznercloud/hcloud-csi-driver:1.1.5
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
@@ -197,7 +197,7 @@ spec:
           securityContext:
             privileged: true
         - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.1.4
+          image: hetznercloud/hcloud-csi-driver:1.1.5
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT


### PR DESCRIPTION
This was forgotten when version 1.1.5 was released in cb459bfd5e7cad9751dac2026227754820abd664.