### PR TITLE
Fix rbac rules for kubernetes v1.16

### DIFF
--- a/deploy/kubernetes/hcloud-csi-master.yml
+++ b/deploy/kubernetes/hcloud-csi-master.yml
@@ -32,8 +32,11 @@ rules:
     resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   # provisioner
   - apiGroups: [""]
     resources: ["secrets"]

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -32,8 +32,11 @@ rules:
     resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   # provisioner
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
Kubernetes v1.16 clusters require access to the
csinodes.storage.k8s.io resource and PATCH rights to
volumeattachments.storage.k8s.io.

Fixes #65  and #77 

Signed-off-by: Christian Beneke <c.beneke@wirelab.org>