### PR TITLE
Add api token length validation

### DIFF
--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -60,6 +60,13 @@ func main() {
 		os.Exit(2)
 	}
 
+	if len(apiToken) != 64 {
+		level.Error(logger).Log(
+			"msg", "entered token is invalid (must be exactly 64 characters long)",
+		)
+		os.Exit(2)
+	}
+
 	hcloudServerID := getServerID()
 
 	hcloudClient := hcloud.NewClient(


### PR DESCRIPTION
Sometimes customers have problems to use the CSI driver because they entered the wrong API token. This should give them a better (and more helpful) error message.