### PR TITLE
Add option to tune log verbosity

### DIFF
--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -27,6 +27,7 @@ var logger log.Logger
 
 func main() {
 	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+	logger = level.NewFilter(logger, parseLogLevel(os.Getenv("LOG_LEVEL")))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 
 	endpoint := os.Getenv("CSI_ENDPOINT")
@@ -232,6 +233,21 @@ func getInstanceID() (int, error) {
 		return 0, err
 	}
 	return strconv.Atoi(string(body))
+}
+
+func parseLogLevel(lvl string) level.Option {
+	switch lvl {
+	case "debug":
+		return level.AllowDebug()
+	case "info":
+		return level.AllowInfo()
+	case "warn":
+		return level.AllowWarn()
+	case "error":
+		return level.AllowError()
+	default:
+		return level.AllowAll()
+	}
 }
 
 func requestLogger(logger log.Logger) grpc.UnaryServerInterceptor {


### PR DESCRIPTION
Currently there's no way to turn down logging verbosity for the csi-driver component. This can be a bit painful, especially due to request logging of healthchecks.

This PR adds an option to change log level verbosity using environment variable "LOG_LEVEL" which can be set to info,warn,error or debug. By default all log lines are logged (AllowAll) which is the same as the current behavior.