### PR TITLE
Specify ndots dns config for hcloud-csi-driver

### DIFF
--- a/deploy/kubernetes/hcloud-csi-1.13.yml
+++ b/deploy/kubernetes/hcloud-csi-1.13.yml
@@ -157,6 +157,10 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -234,3 +238,7 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/deploy/kubernetes/hcloud-csi-master.yml
+++ b/deploy/kubernetes/hcloud-csi-master.yml
@@ -197,6 +197,10 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -309,6 +313,10 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -192,6 +192,10 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -299,6 +303,10 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
It doesn't hurt to be be explicit about it and avoids failure (e.g., with kubespray deployments).

Fixes one possible reason of #139

See https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html for more information.