### PR TITLE
Chore: use recommended/latest CSIDriver apiVersion

### DIFF
--- a/deploy/kubernetes/hcloud-csi-master.yml
+++ b/deploy/kubernetes/hcloud-csi-master.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.hetzner.cloud

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.hetzner.cloud


### PR DESCRIPTION
Today I created a new Kubernetes cluster (v1.19.4) on a Hetzner node. Everything worked in the normal way, except for a minor "cosmetic" issue when I setup the Hetzner `csi-driver` following the [README](https://github.com/hetznercloud/csi-driver#getting-started). At that point I saw the following warning:

```
$ kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.5.1/deploy/kubernetes/hcloud-csi.yml
Warning: storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1 CSIDriver
```

This PR is very simple and is intended to silence this warning by adopting the currently recommended `apiVersion`. I wanted to "scratch the itch" even if it's largely cosmetic for future Hetzner csi-driver users.

NOTE: I haven't tested this thoroughly, the key assumption I'm making is the actual API continues to be compatible. I believe this is the case, based on looking at the k8s public [changelog](https://kubernetes-csi.github.io/docs/kubernetes-changelog.html#deprecations-1), but please actually confirm this before merging. :)

[upstream docs](https://kubernetes-csi.github.io/docs/csi-driver-object.html)
[mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
[CSIDriver going GA in Kubernetes 1.18](https://groups.google.com/g/kubernetes-sig-storage/c/144vT_6HYOQ/m/5xV13jycAAAJ)