### PR TITLE
Add BTRFS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ADD . /csi/
 RUN CGO_ENABLED=0 go build -o driver.bin github.com/hetznercloud/csi-driver/cmd/driver
 
 FROM alpine:3.13
-RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra
+RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra btrfs-progs
 COPY --from=builder /csi/driver.bin /bin/hcloud-csi-driver
 ENTRYPOINT ["/bin/hcloud-csi-driver"]


### PR DESCRIPTION
Starting with v1.21, Kubernetes will fully support BTRFS volumes, including resize: https://github.com/kubernetes/kubernetes/pull/99361.