### PR TITLE
Fix image tag for v1.5.2

### DIFF
--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -147,7 +147,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.5.2
+          image: hetznercloud/hcloud-csi-driver:v1.5.2
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
@@ -243,7 +243,7 @@ spec:
           securityContext:
             privileged: true
         - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.5.2
+          image: hetznercloud/hcloud-csi-driver:v1.5.2
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT


### PR DESCRIPTION
With v1.5.2, the csi-driver starts to prefix the version with a `v`.

This PR fixes the deloyment yaml file not being conformant with this change.