### PR TITLE
Separate server ID from location

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,17 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
 
 ## Integration with Root Servers
 
-Root servers can be part of the cluster, but the CSI plugin doesn't work there. Taint the root server as follows to skip that node for the daemonset.
+Root servers can be part of the cluster, but the CSI plugin functionality
+is limited there.
+
+Taint the root server as follows to skip that node for the daemonset.
 
 ```bash
 kubectl taint node <node name> instance.hetzner.cloud/is-root-server:true
 ```
+
+Alternatively you may set `HCLOUD_LOCATION_NAME` for the daemonset for the
+CSI plugin to attach volumes to supported containers.
 
 ## Versioning policy
 


### PR DESCRIPTION
This PR adds support to execute the CSI plugin on a node not hosted on the Hetzner Cloud. It adds a new environment variable `HCLOUD_LOCATION_NAME` used for the controller service to work properly even if no server ID was determined. The node service is deactivated in this case.

A server ID (> -1) found in the environment variable or with the metadata service is always preferred before `HCLOUD_LOCATION_NAME` is considered.

This is useful in a Gardener deployment where the "csi-driver" is not necessarily deployed on a node in the Hetzner Cloud offering but still manages volumes for nodes deployed on the cloud.