### PR TITLE
Add exclude for blockstorage during resize

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -318,9 +318,12 @@ func (s *NodeService) NodeExpandVolume(ctx context.Context, req *proto.NodeExpan
 		return nil, status.Error(codes.Unavailable, fmt.Sprintf("volume %s is not available on this node %v", volume.LinuxDevice, s.server.ID))
 	}
 
-	if err := s.volumeResizeService.Resize(volume, req.VolumePath); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to resize volume: %s", err))
+	if req.VolumeCapability.GetBlock() == nil {
+		if err := s.volumeResizeService.Resize(volume, req.VolumePath); err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to resize volume: %s", err))
+		}
 	}
+
 	resp := &proto.NodeExpandVolumeResponse{
 		CapacityBytes: volume.SizeBytes(),
 	}


### PR DESCRIPTION
This patch skips the filesystem expansion when the volume was requested
in blockstorage mode, preventing issues with unexpected filesystems.

This patch resolved the problem that even in blockstorage mode, the
hcloud-csi tires to run a filesystem expansion when extending the cloud
volume. This can fail for LUKS volumes or volumes using another
unsupported filesystem and prevent the PVC from ever be successfully
expanded.

The easiest way to prevent that is to not fiddling with the filesystem
when the volume is used in block device mode.

Fixes #208 