### PR TITLE
CI improvements for speed and fork-friendliness.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.dockerignore
+Dockerfile
+.git/
+.github/
+.gitlab-ci.yml
+.idea/
+CHANGES.md
+LICENSE
+README.md
+e2etests/
+deploy/
+mock/
+script/
+**/*_test.go

--- a/.github/workflows/publish_on_master.yml
+++ b/.github/workflows/publish_on_master.yml
@@ -4,19 +4,23 @@ on:
     branches:
       - master
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
       - uses: actions/checkout@master
-      - name: Publish latest tag to registry
-        env:
-            DOCKER_USER: ${{ secrets.DOCKER_USER }}
-            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          docker version
-          docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-          docker build -t hetznercloud/hcloud-csi-driver:latest .
-          docker push hetznercloud/hcloud-csi-driver:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ github.repository_owner }}/hcloud-csi-driver:latest
+          cache-from: type=registry,ref=${{ github.repository_owner }}/hcloud-csi-driver:buildcache
+          cache-to: type=registry,ref=${{ github.repository_owner }}/hcloud-csi-driver:buildcache,mode=max

--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -1,23 +1,28 @@
-name: Push latest version
+name: Push tagged version
 on:
   push:
     tags:
       - 'v*.*.*'
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
       - uses: actions/checkout@master
-      - name: Publish tag to registry
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          export RELEASE_VERSION=$(echo ${GITHUB_REF:11})
-          docker version
-          docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-          docker build -t hetznercloud/hcloud-csi-driver:$RELEASE_VERSION .
-          docker push hetznercloud/hcloud-csi-driver:$RELEASE_VERSION
+      - id: release_version
+        run: echo ::set-output name=value::${GITHUB_REF:11}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ github.repository_owner }}/hcloud-csi-driver:${{ steps.release_version.outputs.value}}
+          cache-from: type=registry,ref=${{ github.repository_owner }}/hcloud-csi-driver:buildcache
+          cache-to: type=registry,ref=${{ github.repository_owner }}/hcloud-csi-driver:buildcache,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,14 @@ jobs:
         with:
           go-version: '1.16'
       - uses: actions/checkout@master
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Run tests
         run: |
           go vet ./...

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -36,6 +36,14 @@ jobs:
       if: steps.check_tts.outputs.hcloud_token_set == 'false' && steps.check_tts.outputs.tts_token_set == 'false'
       run: |
         echo "::error ::Couldn't determine HCLOUD_TOKEN. Check your repository secrets are setup correctly."
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Run tests
       env:
         K8S_VERSION: ${{ matrix.k8s }}


### PR DESCRIPTION
Cache Golang modules with actions/cache. This speeds up the unit tests
workflow about 3x (from ~1m30s to ~20s).

.dockerignore to ensure only code changes cause Docker context to change
and require a Golang rebuild.

Switch Docker builds to use official Docker images powered by BuildKit.
These builds run in parallel, and also cache layers between workflow
executions. The new builder, if hitting a fully primed cache, can finish
in 30 seconds (down from ~2-3m).

Images are tagged by scoping the Docker Hub organization to the repo
owner. Thus it's possible to fork the project and set DOCKER_USER +
DOCKER_PASSWORD in the fork environment and produce release artifacts
easily.

---

You can see some examples of the updated tag release CI here: https://github.com/samcday/csi-driver/actions/workflows/publish_on_tag.yml