### PR TITLE
Reduce default log verbosity to info level

### DIFF
--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -267,7 +267,7 @@ func parseLogLevel(lvl string) level.Option {
 	case "error":
 		return level.AllowError()
 	default:
-		return level.AllowAll()
+		return level.AllowInfo()
 	}
 }
 

--- a/deploy/kubernetes/hcloud-csi-master.yml
+++ b/deploy/kubernetes/hcloud-csi-master.yml
@@ -116,7 +116,6 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-            - --v=5
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -129,7 +128,6 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-            - --v=5
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -144,7 +142,6 @@ spec:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
             - --feature-gates=Topology=true
             - --default-fstype=ext4
-            - --v=5
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -242,7 +239,6 @@ spec:
         - name: csi-node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
-            - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/csi.sock
           env:

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -116,7 +116,6 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-            - --v=5
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -129,7 +128,6 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-            - --v=5
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -144,7 +142,6 @@ spec:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
             - --feature-gates=Topology=true
             - --default-fstype=ext4
-            - --v=5
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -233,7 +230,6 @@ spec:
         - name: csi-node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
-            - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/csi.sock
           env:

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -241,11 +241,11 @@ func (s *hcloudK8sSetup) PrepareK8s() (string, error) {
 
 	patch := `{"spec":{"template":{"spec":{"containers":[{"name":"hcloud-csi-driver","env":[{"name":"LOG_LEVEL","value":"debug"}]}]}}}}`
 	fmt.Printf("[%s] %s: Patch deployment for debug logging\n", s.MainNode.Name, op)
-	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch statefulset hcloud-csi-controller --patch '%s'", patch))
+	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch statefulset hcloud-csi-controller -n kube-system --patch '%s'", patch))
 	if err != nil {
 		return "", fmt.Errorf("%s Patch StatefulSet: %s", op, err)
 	}
-	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch daemonset hcloud-csi-node --patch '%s'", patch))
+	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch daemonset hcloud-csi-node -n kube-system --patch '%s'", patch))
 	if err != nil {
 		return "", fmt.Errorf("%s Patch DaemonSet: %s", op, err)
 	}

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -239,6 +239,17 @@ func (s *hcloudK8sSetup) PrepareK8s() (string, error) {
 		return "", fmt.Errorf("%s Deploy csi: %s", op, err)
 	}
 
+	patch := `{"spec":{"template":{"spec":{"containers":[{"name":"hcloud-csi-driver","env":[{"name":"LOG_LEVEL","value":"debug"}]}]}}}}`
+	fmt.Printf("[%s] %s: Patch deployment for debug logging\n", s.MainNode.Name, op)
+	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch statefulset hcloud-csi-controller --patch '%s'", patch))
+	if err != nil {
+		return "", fmt.Errorf("%s Patch StatefulSet: %s", op, err)
+	}
+	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch daemonset hcloud-csi-node --patch '%s'", patch))
+	if err != nil {
+		return "", fmt.Errorf("%s Patch DaemonSet: %s", op, err)
+	}
+
 	fmt.Printf("[%s] %s: Ensure Server is not labeled as master\n", s.MainNode.Name, op)
 	err = RunCommandOnServer(s.privKey, s.MainNode, "KUBECONFIG=/root/.kube/config kubectl label nodes --all node-role.kubernetes.io/master-")
 	if err != nil {


### PR DESCRIPTION
The debug logging is not useful for end-users. It's also quite spammy
because the regular liveness probes cause an endless amount of noise in
the logs.

During e2e testing it's much more useful, so we patch the deployment
to set the log level back to debug there.

closes #209 