### PR TITLE
Add k8s 1.22 to tests

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [ k8s-1.19.10, k8s-1.20.6, k8s-1.21.0 ]
+        k8s: [ k8s-1.19.10, k8s-1.20.6, k8s-1.21.0, k8s-1.22.0 ]
     name: k8s ${{ matrix.k8s }}
     steps:
     - uses: actions/setup-go@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,3 +47,8 @@ k8s 1.21:
   <<: *k8se2e
   variables:
     K8S_VERSION: k8s-1.21.0
+
+k8s 1.22:
+  <<: *k8se2e
+  variables:
+    K8S_VERSION: k8s-1.22.0

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -92,10 +92,7 @@ func (s *hcloudK8sSetup) PrepareTestEnv(ctx context.Context, additionalSSHKeys [
 	}
 
 	fmt.Printf("[cluster-node] %s Load Image:\n", op)
-	transferCmd := "docker load --input ci-hcloud-csi-driver.tar"
-	if s.K8sDistribution == K8sDistributionK3s {
-		transferCmd = "ctr -n=k8s.io image import ci-hcloud-csi-driver.tar"
-	}
+	transferCmd := "ctr -n=k8s.io image import ci-hcloud-csi-driver.tar"
 	err = RunCommandOnServer(s.privKey, s.MainNode, transferCmd)
 	if err != nil {
 		return fmt.Errorf("%s: Load image %s", op, err)
@@ -145,10 +142,9 @@ func (s *hcloudK8sSetup) createClusterWorker(ctx context.Context, additionalSSHK
 	}
 
 	fmt.Printf("[%s] %s Load Image\n", srv.Name, op)
-	transferCmd := "docker load --input ci-hcloud-csi-driver.tar"
-	if s.K8sDistribution == K8sDistributionK3s {
-		transferCmd = "ctr -n=k8s.io image import ci-hcloud-csi-driver.tar"
-	}
+
+	transferCmd := "ctr -n=k8s.io image import ci-hcloud-csi-driver.tar"
+
 	err = RunCommandOnServer(s.privKey, srv, transferCmd)
 	if err != nil {
 		fmt.Printf("[%s] %s: load image on worker: %v", srv.Name, op, err)


### PR DESCRIPTION
This also moves the container runtime in our tests from docker to containerd

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>