### PR TITLE
Increase default polling interval to 3 seconds.

### DIFF
--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -78,7 +78,7 @@ func main() {
 		opts = append(opts, hcloud.WithDebugWriter(os.Stdout))
 	}
 
-	pollingInterval := 1
+	pollingInterval := 3
 	if customPollingInterval := os.Getenv("HCLOUD_POLLING_INTERVAL_SECONDS"); customPollingInterval != "" {
 		tmp, err := strconv.Atoi(customPollingInterval)
 		if err != nil || tmp < 1 {


### PR DESCRIPTION
Calling the API every second is not needed as most actions are done in less than three seconds, so we can easily save a few API requests here.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>