### PR TITLE
Move everything into DaemonSet, delete StatefulSet

### DIFF
--- a/deploy/kubernetes/hcloud-csi-master.yml
+++ b/deploy/kubernetes/hcloud-csi-master.yml
@@ -80,6 +80,10 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # leader election (attacher, provisioner, resizer)
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,91 +97,6 @@ roleRef:
   kind: ClusterRole
   name: hcloud-csi
   apiGroup: rbac.authorization.k8s.io
----
-kind: StatefulSet
-apiVersion: apps/v1
-metadata:
-  name: hcloud-csi-controller
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      app: hcloud-csi-controller
-  serviceName: hcloud-csi-controller
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: hcloud-csi-controller
-    spec:
-      serviceAccount: hcloud-csi
-      containers:
-        - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-        - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-        - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-          args:
-            - --feature-gates=Topology=true
-            - --default-fstype=ext4
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-        - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:latest
-          imagePullPolicy: Always
-          env:
-            - name: CSI_ENDPOINT
-              value: unix:///run/csi/socket
-            - name: METRICS_ENDPOINT
-              value: 0.0.0.0:9189
-            - name: ENABLE_METRICS
-              value: "true"
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-            - name: HCLOUD_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hcloud-csi
-                  key: token
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-          ports:
-            - containerPort: 9189
-              name: metrics
-            - name: healthz
-              containerPort: 9808
-              protocol: TCP
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /healthz
-              port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 2
-          securityContext:
-            privileged: true
-        - name: liveness-probe
-          imagePullPolicy: Always
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
-          volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-      volumes:
-        - name: socket-dir
-          emptyDir: {}
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -213,6 +132,13 @@ spec:
                     - "true"
       serviceAccount: hcloud-csi
       containers:
+        - name: csi-attacher
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          args:
+            - --leader-election
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /run/csi
         - name: csi-node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
@@ -256,8 +182,6 @@ spec:
               mountPath: /run/csi
             - name: device-dir
               mountPath: /dev
-          securityContext:
-            privileged: true
           ports:
             - containerPort: 9189
               name: metrics
@@ -295,22 +219,6 @@ spec:
           hostPath:
             path: /dev
             type: Directory
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: hcloud-csi-controller-metrics
-  namespace: kube-system
-  labels:
-    app: hcloud-csi
-spec:
-  selector:
-    app: hcloud-csi-controller
-  ports:
-    - port: 9189
-      name: metrics
-      targetPort: metrics
-
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -80,6 +80,10 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # leader election (attacher, provisioner, resizer)
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,91 +97,6 @@ roleRef:
   kind: ClusterRole
   name: hcloud-csi
   apiGroup: rbac.authorization.k8s.io
----
-kind: StatefulSet
-apiVersion: apps/v1
-metadata:
-  name: hcloud-csi-controller
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      app: hcloud-csi-controller
-  serviceName: hcloud-csi-controller
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: hcloud-csi-controller
-    spec:
-      serviceAccount: hcloud-csi
-      containers:
-        - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-        - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-        - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-          args:
-            - --feature-gates=Topology=true
-            - --default-fstype=ext4
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-        - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.6.0
-          imagePullPolicy: Always
-          env:
-            - name: CSI_ENDPOINT
-              value: unix:///run/csi/socket
-            - name: METRICS_ENDPOINT
-              value: 0.0.0.0:9189
-            - name: ENABLE_METRICS
-              value: "true"
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-            - name: HCLOUD_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hcloud-csi
-                  key: token
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
-          ports:
-            - containerPort: 9189
-              name: metrics
-            - name: healthz
-              containerPort: 9808
-              protocol: TCP
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /healthz
-              port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 2
-          securityContext:
-            privileged: true
-        - name: liveness-probe
-          imagePullPolicy: Always
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
-          volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-      volumes:
-        - name: socket-dir
-          emptyDir: {}
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -213,6 +132,13 @@ spec:
                       - "true"
       serviceAccount: hcloud-csi
       containers:
+        - name: csi-attacher
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          args:
+            - --leader-election
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /run/csi
         - name: csi-node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
@@ -256,8 +182,6 @@ spec:
               mountPath: /run/csi
             - name: device-dir
               mountPath: /dev
-          securityContext:
-            privileged: true
           ports:
             - containerPort: 9189
               name: metrics
@@ -295,22 +219,6 @@ spec:
           hostPath:
             path: /dev
             type: Directory
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: hcloud-csi-controller-metrics
-  namespace: kube-system
-  labels:
-    app: hcloud-csi
-spec:
-  selector:
-    app: hcloud-csi-controller
-  ports:
-    - port: 9189
-      name: metrics
-      targetPort: metrics
-
 ---
 apiVersion: v1
 kind: Service

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -237,10 +237,6 @@ func (s *hcloudK8sSetup) PrepareK8s() (string, error) {
 
 	patch := `{"spec":{"template":{"spec":{"containers":[{"name":"hcloud-csi-driver","env":[{"name":"LOG_LEVEL","value":"debug"}]}]}}}}`
 	fmt.Printf("[%s] %s: Patch deployment for debug logging\n", s.MainNode.Name, op)
-	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch statefulset hcloud-csi-controller -n kube-system --patch '%s'", patch))
-	if err != nil {
-		return "", fmt.Errorf("%s Patch StatefulSet: %s", op, err)
-	}
 	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch daemonset hcloud-csi-node -n kube-system --patch '%s'", patch))
 	if err != nil {
 		return "", fmt.Errorf("%s Patch DaemonSet: %s", op, err)


### PR DESCRIPTION
The CSI attacher, provisioner and resizer sidecars all support leader
election already, once granted appropriate Lease API permissions.

---

[Green e2e tests on 1.19, 1.20, 1.21](https://github.com/samcday/csi-driver/actions/runs/1168219649)