### PR TITLE
e2e test workflow improvements

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -1,9 +1,5 @@
 name: Run e2e tests
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push]
 concurrency: ci-${{ github.ref }}
 jobs:
   test:

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -14,30 +14,22 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Check whether HCLOUD_TOKEN needs to be fetched from TTS
-      id: check_tts
+    - name: HCLOUD_TOKEN
       env:
         TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
         HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
       run: |
-        echo "::set-output name=tts_token_set::${{ env.TTS_TOKEN != '' }}"
-        echo "::set-output name=hcloud_token_set::${{ env.HCLOUD_TOKEN != '' }}"
-    - name: Fetch HCLOUD_TOKEN
-      if: steps.check_tts.outputs.tts_token_set == 'true'
-      env:
-        TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
-      run: |
-        echo "HCLOUD_TOKEN=$(./script/get-token.sh)" >> $GITHUB_ENV
-    - name: Set HCLOUD_TOKEN directly
-      if: steps.check_tts.outputs.hcloud_token_set == 'true'
-      env:
-        HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-      run: |
-        echo "HCLOUD_TOKEN=$HCLOUD_TOKEN" >> $GITHUB_ENV
-    - name: Blow up if no HCLOUD_TOKEN or TTS_TOKEN set.
-      if: steps.check_tts.outputs.hcloud_token_set == 'false' && steps.check_tts.outputs.tts_token_set == 'false'
-      run: |
-        echo "::error ::Couldn't determine HCLOUD_TOKEN. Check your repository secrets are setup correctly."
+        set -ueo pipefail
+        if [[ "${TTS_TOKEN:-}" != "" ]]; then
+          token="$(./script/get-token.sh)"
+          echo "::add-mask::$token"
+          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
+        elif [[ "${HCLOUD_TOKEN:-}" != "" ]]; then
+          echo "HCLOUD_TOKEN=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
+        else
+          echo "::error ::Couldn't determine HCLOUD_TOKEN. Check that repository secrets are setup correctly."
+          exit 1
+        fi
     - uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -1,5 +1,9 @@
 name: Run e2e tests
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -4,6 +4,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+concurrency: ci-${{ github.ref }}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 
 func TestOfficialTestsuite(t *testing.T) {
 	t.Run("parallel tests", func(t *testing.T) {
-		err := RunCommandVisibleOnServer(testCluster.setup.privKey, testCluster.setup.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config ./ginkgo -p -v -focus='External.Storage' -skip='\\[Feature:|\\[Disruptive\\]|\\[Serial\\]' ./e2e.test -- -storage.testdriver=test-driver.yml"))
+		err := RunCommandVisibleOnServer(testCluster.setup.privKey, testCluster.setup.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config ./ginkgo -nodes=6 -v -focus='External.Storage' -skip='\\[Feature:|\\[Disruptive\\]|\\[Serial\\]' ./e2e.test -- -storage.testdriver=test-driver.yml"))
 		if err != nil {
 			t.Error(err)
 		}

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -98,7 +98,7 @@ func (s *hcloudK8sSetup) PrepareTestEnv(ctx context.Context, additionalSSHKeys [
 		return fmt.Errorf("%s: Load image %s", op, err)
 	}
 
-	var workers = 1 // Change this value if you want to have more workers for the test
+	var workers = 3 // Change this value if you want to have more workers for the test
 	var wg sync.WaitGroup
 	for worker := 1; worker <= workers; worker++ {
 		wg.Add(1)


### PR DESCRIPTION
The concurrency changes bring test time down to ~15m, [as you can see here](https://github.com/samcday/csi-driver/actions/runs/1168306054).

I've noticed that pushing the concurrency any higher seems to trigger rate limiting or some kind of problem on the hcloud platform side - I see lots of attach/detach API calls that fail with "unknown_error".

A concurrency of 3 per node seems to be fairly stable. Could maybe push this concurrency higher since we have 3 nodes but I've noticed that scheduler seems reluctant to place the e2e test pods on the control plane node, so better to assume there's only 2 nodes available with a 3 node setup.

Also tried to setup e2e test runs for PRs here, but reverted it because fork workflow runs don't have access to secrets. There are ways to work around this, [see this GitHub blog for example](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). What do you think about setting something like that up?
