### PR TITLE
fix docs:  taints vs label

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
 Root servers can be part of the cluster, but the CSI plugin doesn't work there. Taint the root server as follows to skip that node for the daemonset.
 
 ```bash
-kubectl taint node <node name> instance.hetzner.cloud/is-root-server:true
+kubectl label nodes <node name> instance.hetzner.cloud/is-root-server=true
 ```
 
 ## Versioning policy


### PR DESCRIPTION
The PR https://github.com/hetznercloud/csi-driver/pull/195 introduced `instance.hetzner.cloud/is-root-server` to indicate that the driver should not run in dedicated servers (root servers). However the instructions are incorrect and try to add a taint instead of a label.

This was recognized here: https://github.com/hetznercloud/csi-driver/issues/189#issuecomment-826488883

This PR corrects the corresponding instructions in README.md
