### PR TITLE
[2/???] Rework RBAC to only apply to CSI Controller

### DIFF
--- a/deploy/kubernetes/controller/kustomization.yaml
+++ b/deploy/kubernetes/controller/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- rbac.yaml
 - service.yaml
 - statefulset.yaml

--- a/deploy/kubernetes/controller/rbac.yaml
+++ b/deploy/kubernetes/controller/rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hcloud-csi
+  name: hcloud-csi-controller
   namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hcloud-csi
+  name: hcloud-csi-controller
 rules:
 # attacher
 - apiGroups: [""]
@@ -62,12 +62,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hcloud-csi
+  name: hcloud-csi-controller
 subjects:
 - kind: ServiceAccount
-  name: hcloud-csi
+  name: hcloud-csi-controller
   namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: hcloud-csi
+  name: hcloud-csi-controller
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/controller/statefulset.yaml
+++ b/deploy/kubernetes/controller/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
                 operator: NotIn
                 values:
                 - "true"    
-      serviceAccount: hcloud-csi
+      serviceAccount: hcloud-csi-controller
       containers:
       - name: csi-attacher
         image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1

--- a/deploy/kubernetes/core/kustomization.yaml
+++ b/deploy/kubernetes/core/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - csidriver.yaml
-- rbac.yaml
 - storageclass.yaml

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -12,13 +12,13 @@ volumeBindingMode: WaitForFirstConsumer
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hcloud-csi
+  name: hcloud-csi-controller
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: hcloud-csi
+  name: hcloud-csi-controller
 rules:
 - apiGroups:
   - ""
@@ -154,14 +154,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hcloud-csi
+  name: hcloud-csi-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: hcloud-csi
+  name: hcloud-csi-controller
 subjects:
 - kind: ServiceAccount
-  name: hcloud-csi
+  name: hcloud-csi-controller
   namespace: kube-system
 ---
 apiVersion: v1
@@ -283,7 +283,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      serviceAccount: hcloud-csi
+      serviceAccount: hcloud-csi-controller
       volumes:
       - emptyDir: {}
         name: socket-dir
@@ -379,7 +379,6 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: plugin-dir
-      serviceAccount: hcloud-csi
       tolerations:
       - effect: NoExecute
         operator: Exists

--- a/deploy/kubernetes/node/daemonset.yaml
+++ b/deploy/kubernetes/node/daemonset.yaml
@@ -30,7 +30,6 @@ spec:
                 operator: NotIn
                 values:
                 - "true"
-      serviceAccount: hcloud-csi
       containers:
       - name: csi-node-driver-registrar
         image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0


### PR DESCRIPTION
The ServiceAccount and associated ClusterRole + binding are only
necessary for the Controller StatefulSet. The DaemonSet does not require
any permissions to operate on objects in the cluster, since it is
merely responsible for registering the driver with kubelet.

https://github.com/kubernetes-csi/node-driver-registrar#required-permissions

Slightly arbitrary, but also rename the SA + role + binding to reflect
that it only applies to the controller.