### PR TITLE
[3/???] Switch Controller to Deployment, plus other tweaks

### DIFF
--- a/deploy/kubernetes/controller/deployment.yaml
+++ b/deploy/kubernetes/controller/deployment.yaml
@@ -1,4 +1,4 @@
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: hcloud-csi-controller
@@ -7,23 +7,13 @@ spec:
   selector:
     matchLabels:
       app: hcloud-csi-controller
-  serviceName: hcloud-csi-controller
   replicas: 1
   template:
     metadata:
       labels:
         app: hcloud-csi-controller
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: "instance.hetzner.cloud/is-root-server"
-                operator: NotIn
-                values:
-                - "true"    
-      serviceAccount: hcloud-csi-controller
+      serviceAccountName: hcloud-csi-controller
       containers:
       - name: csi-attacher
         image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
@@ -80,8 +70,6 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 3
           periodSeconds: 2
-        securityContext:
-          privileged: true
       - name: liveness-probe
         imagePullPolicy: Always
         image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0

--- a/deploy/kubernetes/controller/kustomization.yaml
+++ b/deploy/kubernetes/controller/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - rbac.yaml
 - service.yaml
-- statefulset.yaml
+- deployment.yaml

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -195,7 +195,7 @@ spec:
     app: hcloud-csi
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: hcloud-csi-controller
   namespace: kube-system
@@ -204,21 +204,11 @@ spec:
   selector:
     matchLabels:
       app: hcloud-csi-controller
-  serviceName: hcloud-csi-controller
   template:
     metadata:
       labels:
         app: hcloud-csi-controller
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: instance.hetzner.cloud/is-root-server
-                operator: NotIn
-                values:
-                - "true"
       containers:
       - image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
         name: csi-attacher
@@ -272,8 +262,6 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
@@ -283,7 +271,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      serviceAccount: hcloud-csi-controller
+      serviceAccountName: hcloud-csi-controller
       volumes:
       - emptyDir: {}
         name: socket-dir

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -237,9 +237,9 @@ func (s *hcloudK8sSetup) PrepareK8s() (string, error) {
 
 	patch := `{"spec":{"template":{"spec":{"containers":[{"name":"hcloud-csi-driver","env":[{"name":"LOG_LEVEL","value":"debug"}]}]}}}}`
 	fmt.Printf("[%s] %s: Patch deployment for debug logging\n", s.MainNode.Name, op)
-	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch statefulset hcloud-csi-controller -n kube-system --patch '%s'", patch))
+	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch deployment hcloud-csi-controller -n kube-system --patch '%s'", patch))
 	if err != nil {
-		return "", fmt.Errorf("%s Patch StatefulSet: %s", op, err)
+		return "", fmt.Errorf("%s Patch Deployment: %s", op, err)
 	}
 	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config kubectl patch daemonset hcloud-csi-node -n kube-system --patch '%s'", patch))
 	if err != nil {


### PR DESCRIPTION
The controller does not need to be a StatefulSet, it is not inherently
stateful. The various sidecars all perform leader election using the
standard k8s Lease approach.

As part of switching to Deployment, drop the governing serviceName field
which was referencing a non-existent Service anyway.

Also remove the node affinity preventing the Deployment from scheduling
replicas on Hetzner root servers. This is not necessary - the controller
should run on root servers just fine, since it's really just responsible
for issuing requests to Hetzner Cloud API in response to CSI Driver
requests. It's only the Node DaemonSet that should not be scheduled on
root servers.

Finally, drop the privileged security context - the controller is not
performing any privileged operations.