### PR TITLE
[4/???] Remove hcloud API calls from most Node code paths

### DIFF
--- a/deploy/kubernetes/controller/deployment.yaml
+++ b/deploy/kubernetes/controller/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: socket-dir
           mountPath: /run/csi
       - name: hcloud-csi-driver
-        image: hetznercloud/hcloud-csi-driver:1.6.0
+        image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         env:
         - name: CSI_ENDPOINT

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -245,7 +245,7 @@ spec:
             secretKeyRef:
               key: token
               name: hcloud-csi
-        image: hetznercloud/hcloud-csi-driver:1.6.0
+        image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -334,7 +334,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: hetznercloud/hcloud-csi-driver:1.6.0
+        image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/deploy/kubernetes/node/daemonset.yaml
+++ b/deploy/kubernetes/node/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: hcloud-csi-driver
-        image: hetznercloud/hcloud-csi-driver:1.6.0
+        image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         env:
         - name: CSI_ENDPOINT

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -179,7 +179,21 @@ func (s *ControllerService) ControllerPublishVolume(ctx context.Context, req *pr
 		return nil, status.Error(code, fmt.Sprintf("failed to publish volume: %s", err))
 	}
 
-	resp := &proto.ControllerPublishVolumeResponse{}
+	volume, err = s.volumeService.GetByID(ctx, volumeID)
+	if err != nil {
+		switch err {
+		case volumes.ErrVolumeNotFound:
+			return nil, status.Error(codes.NotFound, "volume not found")
+		default:
+			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get volume: %s", err))
+		}
+	}
+
+	resp := &proto.ControllerPublishVolumeResponse{
+		PublishContext: map[string]string{
+			"devicePath": volume.LinuxDevice,
+		},
+	}
 	return resp, nil
 }
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -52,31 +52,17 @@ func (s *NodeService) NodeStageVolume(ctx context.Context, req *proto.NodeStageV
 		return nil, status.Error(codes.InvalidArgument, "missing volume capability")
 	}
 
-	volumeID, err := parseVolumeID(req.VolumeId)
-	if err != nil {
-		return nil, status.Error(codes.NotFound, "volume not found")
-	}
-
-	volume, err := s.volumeService.GetByID(ctx, volumeID)
-	if err != nil {
-		switch err {
-		case volumes.ErrVolumeNotFound:
-			return nil, status.Error(codes.NotFound, "volume not found")
-		default:
-			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get volume: %s", err))
-		}
-	}
-
 	switch {
 	case req.VolumeCapability.GetBlock() != nil:
 		return &proto.NodeStageVolumeResponse{}, nil
 	case req.VolumeCapability.GetMount() != nil:
 		mount := req.VolumeCapability.GetMount()
+		devicePath := req.GetPublishContext()["devicePath"]
 		opts := volumes.MountOpts{
 			FSType:     mount.FsType,
 			Additional: mount.MountFlags,
 		}
-		if err := s.volumeMountService.Stage(volume, req.StagingTargetPath, opts); err != nil {
+		if err := s.volumeMountService.Stage(devicePath, req.StagingTargetPath, opts); err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to stage volume: %s", err))
 		}
 		return &proto.NodeStageVolumeResponse{}, nil
@@ -93,22 +79,7 @@ func (s *NodeService) NodeUnstageVolume(ctx context.Context, req *proto.NodeUnst
 		return nil, status.Error(codes.InvalidArgument, "missing staging target path")
 	}
 
-	volumeID, err := parseVolumeID(req.VolumeId)
-	if err != nil {
-		return nil, status.Error(codes.NotFound, "volume not found")
-	}
-
-	volume, err := s.volumeService.GetByID(ctx, volumeID)
-	if err != nil {
-		switch err {
-		case volumes.ErrVolumeNotFound:
-			return &proto.NodeUnstageVolumeResponse{}, nil
-		default:
-			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get volume: %s", err))
-		}
-	}
-
-	if err := s.volumeMountService.Unstage(volume, req.StagingTargetPath); err != nil {
+	if err := s.volumeMountService.Unstage(req.StagingTargetPath); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to unstage volume: %s", err))
 	}
 
@@ -127,25 +98,12 @@ func (s *NodeService) NodePublishVolume(ctx context.Context, req *proto.NodePubl
 		return nil, status.Error(codes.InvalidArgument, "missing target path")
 	}
 
-	volumeID, err := parseVolumeID(req.VolumeId)
-	if err != nil {
-		return nil, status.Error(codes.NotFound, "volume not found")
-	}
-
-	volume, err := s.volumeService.GetByID(ctx, volumeID)
-	if err != nil {
-		switch err {
-		case volumes.ErrVolumeNotFound:
-			return nil, status.Error(codes.NotFound, "volume not found")
-		default:
-			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get volume: %s", err))
-		}
-	}
+	devicePath := req.GetPublishContext()["devicePath"]
 
 	switch {
 	case req.VolumeCapability.GetBlock() != nil:
 		opts := volumes.MountOpts{BlockVolume: true}
-		if err := s.volumeMountService.Publish(volume, req.TargetPath, volume.LinuxDevice, opts); err != nil {
+		if err := s.volumeMountService.Publish(req.TargetPath, devicePath, opts); err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to publish block volume: %s", err))
 		}
 		return &proto.NodePublishVolumeResponse{}, nil
@@ -156,7 +114,7 @@ func (s *NodeService) NodePublishVolume(ctx context.Context, req *proto.NodePubl
 			Readonly:   req.Readonly,
 			Additional: mount.MountFlags,
 		}
-		if err := s.volumeMountService.Publish(volume, req.TargetPath, req.StagingTargetPath, opts); err != nil {
+		if err := s.volumeMountService.Publish(req.TargetPath, req.StagingTargetPath, opts); err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to publish volume: %s", err))
 		}
 		return &proto.NodePublishVolumeResponse{}, nil
@@ -173,22 +131,7 @@ func (s *NodeService) NodeUnpublishVolume(ctx context.Context, req *proto.NodeUn
 		return nil, status.Error(codes.InvalidArgument, "missing target path")
 	}
 
-	volumeID, err := parseVolumeID(req.VolumeId)
-	if err != nil {
-		return nil, status.Error(codes.NotFound, "volume not found")
-	}
-
-	volume, err := s.volumeService.GetByID(ctx, volumeID)
-	if err != nil {
-		switch err {
-		case volumes.ErrVolumeNotFound:
-			return &proto.NodeUnpublishVolumeResponse{}, nil
-		default:
-			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get volume: %s", err))
-		}
-	}
-
-	if err := s.volumeMountService.Unpublish(volume, req.TargetPath); err != nil {
+	if err := s.volumeMountService.Unpublish(req.TargetPath); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to unpublish volume: %s", err))
 	}
 

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -186,19 +186,19 @@ func (s *sanityVolumeService) Detach(ctx context.Context, volume *csi.Volume, se
 
 type sanityMountService struct{}
 
-func (s *sanityMountService) Stage(volume *csi.Volume, stagingTargetPath string, opts volumes.MountOpts) error {
+func (s *sanityMountService) Stage(devicePath string, stagingTargetPath string, opts volumes.MountOpts) error {
 	return nil
 }
 
-func (s *sanityMountService) Unstage(volume *csi.Volume, stagingTargetPath string) error {
+func (s *sanityMountService) Unstage(stagingTargetPath string) error {
 	return nil
 }
 
-func (s *sanityMountService) Publish(volume *csi.Volume, targetPath string, stagingTargetPath string, opts volumes.MountOpts) error {
+func (s *sanityMountService) Publish(targetPath string, stagingTargetPath string, opts volumes.MountOpts) error {
 	return nil
 }
 
-func (s *sanityMountService) Unpublish(volume *csi.Volume, targetPath string) error {
+func (s *sanityMountService) Unpublish(targetPath string) error {
 	return nil
 }
 

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -67,32 +67,32 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 }
 
 type VolumeMountService struct {
-	StageFunc      func(volume *csi.Volume, stagingTargetPath string, opts volumes.MountOpts) error
-	UnstageFunc    func(volume *csi.Volume, stagingTargetPath string) error
-	PublishFunc    func(volume *csi.Volume, targetPath string, stagingTargetPath string, opts volumes.MountOpts) error
-	UnpublishFunc  func(volume *csi.Volume, targetPath string) error
+	StageFunc      func(devicePath string, stagingTargetPath string, opts volumes.MountOpts) error
+	UnstageFunc    func(stagingTargetPath string) error
+	PublishFunc    func(targetPath string, stagingTargetPath string, opts volumes.MountOpts) error
+	UnpublishFunc  func(targetPath string) error
 	PathExistsFunc func(path string) (bool, error)
 }
 
-func (s *VolumeMountService) Stage(volume *csi.Volume, stagingTargetPath string, opts volumes.MountOpts) error {
+func (s *VolumeMountService) Stage(devicePath string, stagingTargetPath string, opts volumes.MountOpts) error {
 	if s.StageFunc == nil {
 		panic("not implemented")
 	}
-	return s.StageFunc(volume, stagingTargetPath, opts)
+	return s.StageFunc(devicePath, stagingTargetPath, opts)
 }
 
-func (s *VolumeMountService) Unstage(volume *csi.Volume, stagingTargetPath string) error {
+func (s *VolumeMountService) Unstage(stagingTargetPath string) error {
 	if s.UnstageFunc == nil {
 		panic("not implemented")
 	}
-	return s.UnstageFunc(volume, stagingTargetPath)
+	return s.UnstageFunc(stagingTargetPath)
 }
 
-func (s *VolumeMountService) Publish(volume *csi.Volume, targetPath string, stagingTargetPath string, opts volumes.MountOpts) error {
+func (s *VolumeMountService) Publish(targetPath string, stagingTargetPath string, opts volumes.MountOpts) error {
 	if s.PublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.PublishFunc(volume, targetPath, stagingTargetPath, opts)
+	return s.PublishFunc(targetPath, stagingTargetPath, opts)
 }
 
 func (s *VolumeMountService) PathExists(path string) (bool, error) {
@@ -102,11 +102,11 @@ func (s *VolumeMountService) PathExists(path string) (bool, error) {
 	return s.PathExistsFunc(path)
 }
 
-func (s *VolumeMountService) Unpublish(volume *csi.Volume, targetPath string) error {
+func (s *VolumeMountService) Unpublish(targetPath string) error {
 	if s.UnpublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.UnpublishFunc(volume, targetPath)
+	return s.UnpublishFunc(targetPath)
 }
 
 type VolumeResizeService struct {

--- a/volumes/mount.go
+++ b/volumes/mount.go
@@ -9,8 +9,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/exec"
-
-	"github.com/hetznercloud/csi-driver/csi"
 )
 
 const DefaultFSType = "ext4"
@@ -25,10 +23,10 @@ type MountOpts struct {
 
 // MountService mounts volumes.
 type MountService interface {
-	Stage(volume *csi.Volume, stagingTargetPath string, opts MountOpts) error
-	Unstage(volume *csi.Volume, stagingTargetPath string) error
-	Publish(volume *csi.Volume, targetPath string, stagingTargetPath string, opts MountOpts) error
-	Unpublish(volume *csi.Volume, targetPath string) error
+	Stage(devicePath string, stagingTargetPath string, opts MountOpts) error
+	Unstage(stagingTargetPath string) error
+	Publish(targetPath string, stagingTargetPath string, opts MountOpts) error
+	Unpublish(targetPath string) error
 	PathExists(path string) (bool, error)
 }
 
@@ -48,14 +46,14 @@ func NewLinuxMountService(logger log.Logger) *LinuxMountService {
 	}
 }
 
-func (s *LinuxMountService) Stage(volume *csi.Volume, stagingTargetPath string, opts MountOpts) error {
+func (s *LinuxMountService) Stage(devicePath string, stagingTargetPath string, opts MountOpts) error {
 	if opts.FSType == "" {
 		opts.FSType = DefaultFSType
 	}
 
 	level.Debug(s.logger).Log(
 		"msg", "staging volume",
-		"volume-name", volume.Name,
+		"device-path", devicePath,
 		"staging-target-path", stagingTargetPath,
 		"fs-type", opts.FSType,
 	)
@@ -75,19 +73,18 @@ func (s *LinuxMountService) Stage(volume *csi.Volume, stagingTargetPath string, 
 		return nil
 	}
 
-	return s.mounter.FormatAndMount(volume.LinuxDevice, stagingTargetPath, opts.FSType, nil)
+	return s.mounter.FormatAndMount(devicePath, stagingTargetPath, opts.FSType, nil)
 }
 
-func (s *LinuxMountService) Unstage(volume *csi.Volume, stagingTargetPath string) error {
+func (s *LinuxMountService) Unstage(stagingTargetPath string) error {
 	level.Debug(s.logger).Log(
 		"msg", "unstaging volume",
-		"volume-name", volume.Name,
 		"staging-target-path", stagingTargetPath,
 	)
 	return mount.CleanupMountPoint(stagingTargetPath, s.mounter, false)
 }
 
-func (s *LinuxMountService) Publish(volume *csi.Volume, targetPath string, stagingTargetPath string, opts MountOpts) error {
+func (s *LinuxMountService) Publish(targetPath string, stagingTargetPath string, opts MountOpts) error {
 	isNotMountPoint, err := mount.IsNotMountPoint(s.mounter, targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -129,7 +126,6 @@ func (s *LinuxMountService) Publish(volume *csi.Volume, targetPath string, stagi
 
 	level.Debug(s.logger).Log(
 		"msg", "publishing volume",
-		"volume-name", volume.Name,
 		"target-path", targetPath,
 		"staging-target-path", stagingTargetPath,
 		"fs-type", opts.FSType,
@@ -145,10 +141,9 @@ func (s *LinuxMountService) Publish(volume *csi.Volume, targetPath string, stagi
 	return nil
 }
 
-func (s *LinuxMountService) Unpublish(volume *csi.Volume, targetPath string) error {
+func (s *LinuxMountService) Unpublish(targetPath string) error {
 	level.Debug(s.logger).Log(
 		"msg", "unpublishing volume",
-		"volume-name", volume.Name,
 		"target-path", targetPath,
 	)
 	return mount.CleanupMountPoint(targetPath, s.mounter, true)


### PR DESCRIPTION
In the various Node stage/unstage/publish/unpublish methods there was an
established pattern of requiring the csi.Volume object so that an API
call could be made to look up the volume details from the Hetzner Cloud
API.

In most of the code paths (unstaging, unpublishing in particular), this
lookup is entirely unnecessary. In fact the returned Volume object was
not being used for anything other than a log.Debug call.

In the case of the stage/publish calls, the volume lookup provided the
required LinuxDevice field (so the Node driver knows where the volume
is actually located in /dev). In this case, however, the CSI spec offers
a better alternative - PublishContext.

The ControllerPublishVolume call is responsible for doing the actual
attach of a hcloud volume to a particular node. The response allows some
arbitrary key/value (map[string]string) data to be returned. This is the
perfect time to provide the necessary LinuxDevice information. This
context is then provided to the Node Publish/Stage methods.

There's a few advantages to this change:

 * Reduce calls to the hcloud API server.
 * Reduce the privilege necessary for the Node DaemonSet.
 * ~350 less lines of code

The second point can't be fully realized yet - it's my intent to remove
the HCLOUD_TOKEN from the DaemonSet altogether. But I can't, just yet.

Unfortunately the resize code path will require a bit more work, but I'm
sure I'll be able to achieve that in some follow-up work, at which point
I will also do the removal of the HCLOUD_TOKEN from the DaemonSet.