### PR TITLE
[6/???] Simplify node resize

### DIFF
--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -211,7 +211,7 @@ func (s *sanityMountService) PathExists(path string) (bool, error) {
 
 type sanityResizeService struct{}
 
-func (s *sanityResizeService) Resize(volume *csi.Volume, volumePath string) error {
+func (s *sanityResizeService) Resize(volumePath string) error {
 	return nil
 }
 

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -110,14 +110,14 @@ func (s *VolumeMountService) Unpublish(targetPath string) error {
 }
 
 type VolumeResizeService struct {
-	ResizeFunc func(volume *csi.Volume, volumePath string) error
+	ResizeFunc func(volumePath string) error
 }
 
-func (s *VolumeResizeService) Resize(volume *csi.Volume, volumePath string) error {
+func (s *VolumeResizeService) Resize(volumePath string) error {
 	if s.ResizeFunc == nil {
 		panic("not implemented")
 	}
-	return s.ResizeFunc(volume, volumePath)
+	return s.ResizeFunc(volumePath)
 }
 
 type VolumeStatsService struct {


### PR DESCRIPTION
Similar to the earlier work to remove volume lookup API calls in the
other Node RPC code paths. In this case we're doing some slightly scary
stuff, but I promise you it's all very legit and above board.

For starters, instead of using the canonical LinuxDevice path from the
API response, we use the mount-utils package to determine the device
path from the given volume path (where the device is actually mounted).
This should be completely safe - there's a nice library method for it,
after all. And there should never be a situation where Linux doesn't
know *what* device is mounted at a given path. Further, the CSI spec
clearly states that NodeExpandVolume MUST be called after the Stage and
Publish calls. So we'll only ever be asked to expand a volume that has
already been mounted.

The other slightly fishy change is to remove the CapacityBytes field
in NodeExpandVolumeResponse. Since we're not looking up the volume
any more, we don't really know this information (and don't really care).
We could of course determine it by actually looking at the device path
and seeing how many bytes Linux is reporting for it. I opted to just
remove it, since the spec states this field is optional. I'm not sure
why it's even there, really, since the ControllerExpandVolume is also
providing it.

https://github.com/container-storage-interface/spec/blob/master/spec.md#nodeexpandvolume