### PR TITLE
[7/???] Rework Node topology and remove HCLOUD_TOKEN use

### DIFF
--- a/api/volume.go
+++ b/api/volume.go
@@ -65,6 +65,11 @@ func (s *VolumeService) Create(ctx context.Context, opts volumes.CreateOpts) (*c
 	return toDomainVolume(result.Volume), nil
 }
 
+func (s *VolumeService) GetServerByID(ctx context.Context, id int) (*hcloud.Server, error) {
+	server, _, err := s.client.Server.GetByID(ctx, id)
+	return server, err
+}
+
 func (s *VolumeService) GetByID(ctx context.Context, id uint64) (*csi.Volume, error) {
 	hcloudVolume, _, err := s.client.Volume.GetByID(ctx, int(id))
 	if err != nil {

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -306,12 +306,6 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        env:
-        - name: KUBE_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
         name: csi-node-driver-registrar
         volumeMounts:
@@ -328,16 +322,6 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        - name: HCLOUD_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: token
-              name: hcloud-csi
-        - name: KUBE_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/kubernetes/node/daemonset.yaml
+++ b/deploy/kubernetes/node/daemonset.yaml
@@ -35,12 +35,6 @@ spec:
         image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
         args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        env:
-        - name: KUBE_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         volumeMounts:
         - name: plugin-dir
           mountPath: /run/csi
@@ -57,16 +51,6 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        - name: HCLOUD_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: hcloud-csi
-              key: token
-        - name: KUBE_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         volumeMounts:
         - name: kubelet-dir
           mountPath: /var/lib/kubelet

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,5 +8,6 @@ const (
 	MinVolumeSize     = 10 // GB
 	DefaultVolumeSize = MinVolumeSize
 
+	TopologySegmentServerID = PluginName + "/server-id"
 	TopologySegmentLocation = PluginName + "/location"
 )

--- a/driver/helper.go
+++ b/driver/helper.go
@@ -56,20 +56,3 @@ func isCapabilitySupported(cap *proto.VolumeCapability) bool {
 		return false
 	}
 }
-
-func locationFromTopologyRequirement(tr *proto.TopologyRequirement) *string {
-	if tr == nil {
-		return nil
-	}
-	for _, top := range tr.Preferred {
-		if location, ok := top.Segments[TopologySegmentLocation]; ok {
-			return &location
-		}
-	}
-	for _, top := range tr.Requisite {
-		if location, ok := top.Segments[TopologySegmentLocation]; ok {
-			return &location
-		}
-	}
-	return nil
-}

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -12,12 +13,12 @@ import (
 
 	proto "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/go-kit/kit/log"
-	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/kubernetes-csi/csi-test/v3/pkg/sanity"
 	"google.golang.org/grpc"
 
 	"github.com/hetznercloud/csi-driver/csi"
 	"github.com/hetznercloud/csi-driver/volumes"
+	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
 func TestSanity(t *testing.T) {
@@ -52,15 +53,7 @@ func TestSanity(t *testing.T) {
 	)
 	nodeService := NewNodeService(
 		log.With(logger, "component", "driver-node-service"),
-		&hcloud.Server{
-			ID: 123456,
-			Datacenter: &hcloud.Datacenter{
-				Location: &hcloud.Location{
-					Name: "testloc",
-				},
-			},
-		},
-		volumeService,
+		"123456",
 		volumeMountService,
 		volumeResizeService,
 		volumeStatsService,
@@ -116,6 +109,10 @@ func (s *sanityVolumeService) Create(ctx context.Context, opts volumes.CreateOpt
 
 	s.volumes.PushBack(volume)
 	return volume, nil
+}
+
+func (s *sanityVolumeService) GetServerByID(ctx context.Context, id int) (*hcloud.Server, error) {
+	return nil, errors.New("Not implemented")
 }
 
 func (s *sanityVolumeService) GetByID(ctx context.Context, id uint64) (*csi.Volume, error) {

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -3,18 +3,21 @@ package mock
 import (
 	"context"
 
+	"github.com/hetznercloud/hcloud-go/hcloud"
+
 	"github.com/hetznercloud/csi-driver/csi"
 	"github.com/hetznercloud/csi-driver/volumes"
 )
 
 type VolumeService struct {
-	CreateFunc    func(ctx context.Context, opts volumes.CreateOpts) (*csi.Volume, error)
-	GetByIDFunc   func(ctx context.Context, id uint64) (*csi.Volume, error)
-	GetByNameFunc func(ctx context.Context, name string) (*csi.Volume, error)
-	DeleteFunc    func(ctx context.Context, volume *csi.Volume) error
-	AttachFunc    func(ctx context.Context, volume *csi.Volume, server *csi.Server) error
-	DetachFunc    func(ctx context.Context, volume *csi.Volume, server *csi.Server) error
-	ResizeFunc    func(ctx context.Context, volume *csi.Volume, size int) error
+	CreateFunc        func(ctx context.Context, opts volumes.CreateOpts) (*csi.Volume, error)
+	GetServerByIDFunc func(ctx context.Context, id int) (*hcloud.Server, error)
+	GetByIDFunc       func(ctx context.Context, id uint64) (*csi.Volume, error)
+	GetByNameFunc     func(ctx context.Context, name string) (*csi.Volume, error)
+	DeleteFunc        func(ctx context.Context, volume *csi.Volume) error
+	AttachFunc        func(ctx context.Context, volume *csi.Volume, server *csi.Server) error
+	DetachFunc        func(ctx context.Context, volume *csi.Volume, server *csi.Server) error
+	ResizeFunc        func(ctx context.Context, volume *csi.Volume, size int) error
 }
 
 func (s *VolumeService) Create(ctx context.Context, opts volumes.CreateOpts) (*csi.Volume, error) {
@@ -22,6 +25,13 @@ func (s *VolumeService) Create(ctx context.Context, opts volumes.CreateOpts) (*c
 		panic("not implemented")
 	}
 	return s.CreateFunc(ctx, opts)
+}
+
+func (s *VolumeService) GetServerByID(ctx context.Context, id int) (*hcloud.Server, error) {
+	if s.GetServerByIDFunc == nil {
+		panic("not implemented")
+	}
+	return s.GetServerByIDFunc(ctx, id)
 }
 
 func (s *VolumeService) GetByID(ctx context.Context, id uint64) (*csi.Volume, error) {

--- a/volumes/idempotency.go
+++ b/volumes/idempotency.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 
 	"github.com/hetznercloud/csi-driver/csi"
+	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
 // IdempotentService wraps a volume service and provides idempotency as required by the CSI spec.
@@ -94,6 +95,10 @@ func (s *IdempotentService) Create(ctx context.Context, opts CreateOpts) (*csi.V
 	}
 
 	return nil, err
+}
+
+func (s *IdempotentService) GetServerByID(ctx context.Context, id int) (*hcloud.Server, error) {
+	return s.volumeService.GetServerByID(ctx, id)
 }
 
 func (s *IdempotentService) GetByID(ctx context.Context, id uint64) (*csi.Volume, error) {

--- a/volumes/service.go
+++ b/volumes/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hetznercloud/hcloud-go/hcloud"
+
 	"github.com/hetznercloud/csi-driver/csi"
 )
 
@@ -19,6 +21,7 @@ var (
 
 type Service interface {
 	Create(ctx context.Context, opts CreateOpts) (*csi.Volume, error)
+	GetServerByID(ctx context.Context, id int) (*hcloud.Server, error)
 	GetByID(ctx context.Context, id uint64) (*csi.Volume, error)
 	GetByName(ctx context.Context, name string) (*csi.Volume, error)
 	Delete(ctx context.Context, volume *csi.Volume) error


### PR DESCRIPTION
The final usage of hcloud API required on the node side was to determine
the location of the server to provide a topology hint to the controller
when creating a new volume.

It would be nice if the hcloud metadata service had an endpoint to get
the DC location of the server but alas it does not exist, yet. Hmmmm...

Instead, the node now relies on the metadata service to determine the
ID of the server it's running on. I know in the past there's been issues
with the usage of the metadata service, but from combing through the old
tickets, I'm reasonably confident that stemmed from not having a
distinction between the node and controller parts, which we now have. As
I pointed out in the commit to split the node and controller into
separate binaries, we can always assume the node part is running on a
hcloud server (that's kinda the entire point of it, really), and so we
can rely on the metadata service being reliably reachable.

So with the server ID in hand, the node now provides this in NodeGetInfo
which is then provided to the ControllerCreateVolume call. At this point
the controller uses that server ID hint (if it exists) to determine the
correct location to create the volume in. The topology stuff was already
implemented as a "best effort" deal anyways, with a fallback to use the
location of the controller. So I continue that trend - if the server ID
is present but can't be looked up for some reason, do the fallback.

So now the node is no longer making any hcloud API calls whatsoever, and
the HCLOUD_TOKEN and KUBE_NODE_NAME env vars have been removed entirely.
Architecturally, the node is now in the state I was hoping to get it to:
it's a dumb, unprivileged drone that does the minimum on-node actions,
and nothing more.