### PR TITLE
[8/???] Remove Node Stage/Unstage capability

### DIFF
--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -76,7 +76,6 @@ func TestSanity(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	testConfig := sanity.NewTestConfig()
-	testConfig.StagingPath = tempDir + "/hcloud-csi-sanity-staging"
 	testConfig.TargetPath = tempDir + "/hcloud-csi-sanity-target"
 	testConfig.Address = endpoint
 	sanity.Test(t, testConfig)
@@ -178,15 +177,7 @@ func (s *sanityVolumeService) Detach(ctx context.Context, volume *csi.Volume, se
 
 type sanityMountService struct{}
 
-func (s *sanityMountService) Stage(devicePath string, stagingTargetPath string, opts volumes.MountOpts) error {
-	return nil
-}
-
-func (s *sanityMountService) Unstage(stagingTargetPath string) error {
-	return nil
-}
-
-func (s *sanityMountService) Publish(targetPath string, stagingTargetPath string, opts volumes.MountOpts) error {
+func (s *sanityMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
 	return nil
 }
 

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -70,32 +70,16 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 }
 
 type VolumeMountService struct {
-	StageFunc      func(devicePath string, stagingTargetPath string, opts volumes.MountOpts) error
-	UnstageFunc    func(stagingTargetPath string) error
-	PublishFunc    func(targetPath string, stagingTargetPath string, opts volumes.MountOpts) error
+	PublishFunc    func(targetPath string, devicePath string, opts volumes.MountOpts) error
 	UnpublishFunc  func(targetPath string) error
 	PathExistsFunc func(path string) (bool, error)
 }
 
-func (s *VolumeMountService) Stage(devicePath string, stagingTargetPath string, opts volumes.MountOpts) error {
-	if s.StageFunc == nil {
-		panic("not implemented")
-	}
-	return s.StageFunc(devicePath, stagingTargetPath, opts)
-}
-
-func (s *VolumeMountService) Unstage(stagingTargetPath string) error {
-	if s.UnstageFunc == nil {
-		panic("not implemented")
-	}
-	return s.UnstageFunc(stagingTargetPath)
-}
-
-func (s *VolumeMountService) Publish(targetPath string, stagingTargetPath string, opts volumes.MountOpts) error {
+func (s *VolumeMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
 	if s.PublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.PublishFunc(targetPath, stagingTargetPath, opts)
+	return s.PublishFunc(targetPath, devicePath, opts)
 }
 
 func (s *VolumeMountService) PathExists(path string) (bool, error) {


### PR DESCRIPTION
Since b770ef5 the desired filesystem type is provided to the hcloud API.
As such the formatting no longer happens during the Stage call, making
it entirely unnecessary. Instead, the prepared volume is mounted to the
target location kubelet ultimately wants in the NodePublishVolume RPC
method.

Even if we for some reason wanted to do more fancy stuff on the node
side (I hope not, the whole point of the current patch series is to
reduce the node behaviour down to as minimal as possible), I think that
could just be done during the publish call.

Honestly, it's a bit of a head-scratcher why the stage/unstage
capability exists at all. I guess there's some use case for it, but it
doesn't appear our needs are complex enough to require it.