### PR TITLE
[9/???] Remove topology fallback behaviour

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hetznercloud/csi-driver/app"
 	"github.com/hetznercloud/csi-driver/driver"
 	"github.com/hetznercloud/csi-driver/volumes"
-	"github.com/hetznercloud/hcloud-go/hcloud/metadata"
 )
 
 var logger log.Logger
@@ -29,17 +28,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	metadataClient := metadata.NewClient(metadata.WithInstrumentation(m.Registry()))
-
-	server, err := app.GetServer(logger, hcloudClient, metadataClient)
-	if err != nil {
-		level.Error(logger).Log(
-			"msg", "failed to fetch server",
-			"err", err,
-		)
-		os.Exit(1)
-	}
-
 	volumeService := volumes.NewIdempotentService(
 		log.With(logger, "component", "idempotent-volume-service"),
 		api.NewVolumeService(
@@ -50,7 +38,6 @@ func main() {
 	controllerService := driver.NewControllerService(
 		log.With(logger, "component", "driver-controller-service"),
 		volumeService,
-		server.Datacenter.Location.Name,
 	)
 	identityService := driver.NewIdentityService(
 		log.With(logger, "component", "driver-identity-service"),

--- a/deploy/kubernetes/controller/deployment.yaml
+++ b/deploy/kubernetes/controller/deployment.yaml
@@ -44,11 +44,6 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        - name: KUBE_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         - name: HCLOUD_TOKEN
           valueFrom:
             secretKeyRef:

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -237,11 +237,6 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        - name: KUBE_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         - name: HCLOUD_TOKEN
           valueFrom:
             secretKeyRef:

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -32,7 +32,6 @@ func newControllerServiceTestEnv() *controllerServiceTestEnv {
 		service: NewControllerService(
 			logger,
 			volumeService,
-			"testloc",
 		),
 		volumeService: volumeService,
 	}

--- a/driver/helper.go
+++ b/driver/helper.go
@@ -56,20 +56,3 @@ func isCapabilitySupported(cap *proto.VolumeCapability) bool {
 		return false
 	}
 }
-
-func locationFromTopologyRequirement(tr *proto.TopologyRequirement) *string {
-	if tr == nil {
-		return nil
-	}
-	for _, top := range tr.Preferred {
-		if location, ok := top.Segments[TopologySegmentLocation]; ok {
-			return &location
-		}
-	}
-	for _, top := range tr.Requisite {
-		if location, ok := top.Segments[TopologySegmentLocation]; ok {
-			return &location
-		}
-	}
-	return nil
-}

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -44,7 +44,6 @@ func TestSanity(t *testing.T) {
 	controllerService := NewControllerService(
 		log.With(logger, "component", "driver-controller-service"),
 		volumeService,
-		"testloc",
 	)
 	identityService := NewIdentityService(
 		log.With(logger, "component", "driver-identity-service"),


### PR DESCRIPTION
Using the location of the controller as a fallback if the necessary
topology information is missing is inappropriate for a few reasons:

 * There's no guarantee the location of the controller is the same as
   the node that the volume will be attached to.
 * There's no guarantee the controller will even have a location at all.
   It could be deployed on a root server. It may not be deployed on a
   Hetzner host at all.
 * A fallback that has so many caveats is (arguably) worse than just
   failing fast, to be less confusing in the edge cases where such a
   fallback is necessary in the first place.

Of course the point can be made that in the "simple" cases (a cluster
that only spans one location) this fallback could be useful. That might
be true, but I think that in the simple case, there should never be a
volume provisioning event without the corresponding location information
in the first place :)

Given that the NodeGetInfo method has been simplified in a previous
commit to just grab the necessary information from the metadata service,
I don't anticipate any edge cases that cause a volume to be provisioned
without the appropriate topology hint.