### PR TITLE
Rename secret for hcloud api token to `hcloud`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
    apiVersion: v1
    kind: Secret
    metadata:
-     name: hcloud-csi
+     name: hcloud
      namespace: kube-system
    stringData:
      token: YOURTOKEN

--- a/deploy/kubernetes/controller/deployment.yaml
+++ b/deploy/kubernetes/controller/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: HCLOUD_TOKEN
           valueFrom:
             secretKeyRef:
-              name: hcloud-csi
+              name: hcloud
               key: token
         volumeMounts:
         - name: socket-dir

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -246,7 +246,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: token
-              name: hcloud-csi
+              name: hcloud
         image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         livenessProbe:
@@ -332,7 +332,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: token
-              name: hcloud-csi
+              name: hcloud
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:

--- a/deploy/kubernetes/node/daemonset.yaml
+++ b/deploy/kubernetes/node/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
         - name: HCLOUD_TOKEN
           valueFrom:
             secretKeyRef:
-              name: hcloud-csi
+              name: hcloud
               key: token
         - name: KUBE_NODE_NAME
           valueFrom:

--- a/e2etests/templates/cloudinit_k8s.txt.tpl
+++ b/e2etests/templates/cloudinit_k8s.txt.tpl
@@ -55,7 +55,6 @@ runcmd:
 - until KUBECONFIG=/root/.kube/config kubectl get node; do sleep 2;done
 - KUBECONFIG=/root/.kube/config kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 - KUBECONFIG=/root/.kube/config kubectl -n kube-system patch ds kube-flannel-ds --type json -p '[{"op":"add","path":"/spec/template/spec/tolerations/-","value":{"key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true","effect":"NoSchedule"}}]'
-- KUBECONFIG=/root/.kube/config kubectl -n kube-system create secret generic hcloud-csi --from-literal=token={{.HcloudToken}}
 - KUBECONFIG=/root/.kube/config kubectl -n kube-system create secret generic hcloud --from-literal=token={{.HcloudToken}}
 - KUBECONFIG=/root/.kube/config kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm.yaml
 - cd /root/ && curl  -s --location https://dl.k8s.io/v{{.K8sVersion}}/kubernetes-test-linux-amd64.tar.gz | tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo


### PR DESCRIPTION
We want to unify the name of the token between the Cloud Controller Manager & the CSI Driver. This is already as a preparation for the upcoming version 2 of the csi driver.

Fixes https://github.com/hetznercloud/csi-driver/issues/254

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>