### PR TITLE
Add support for volume encryption with cryptsetup and LUKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN CGO_ENABLED=0 go build -o controller.bin github.com/hetznercloud/csi-driver/
 RUN CGO_ENABLED=0 go build -o node.bin github.com/hetznercloud/csi-driver/cmd/node
 
 FROM alpine:3.13
-RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra btrfs-progs
+RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra btrfs-progs cryptsetup
 COPY --from=builder /csi/controller.bin /bin/hcloud-csi-driver-controller
 COPY --from=builder /csi/node.bin /bin/hcloud-csi-driver-node

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
    kubectl exec -it my-csi-app -- /bin/sh
    ```
 
+5. To add encryption with LUKS you have to create a dedicate secret containing an encryption passphrase and duplicate the default `hcloud-volumes` storage class with added parameters referencing this secret:
+
+   ```
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: encryption-secret
+     namespace: kube-system
+   stringData:
+     encryption-passphrase: foobar
+
+   --- 
+
+   apiVersion: storage.k8s.io/v1
+   kind: StorageClass
+   metadata:
+     name: hcloud-volumes-encrypted
+   provisioner: csi.hetzner.cloud
+   reclaimPolicy: Delete
+   volumeBindingMode: WaitForFirstConsumer
+   allowVolumeExpansion: true
+   parameters:
+     csi.storage.k8s.io/node-publish-secret-name: encryption
+     csi.storage.k8s.io/node-publish-secret-namespace: default
+   ```
+
 ## Integration with Root Servers
 
 Root servers can be part of the cluster, but the CSI plugin doesn't work there. Taint the root server as follows to skip that node for the daemonset.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ related only to an unsupported version.
 | 1.21       | 1.6.0, master | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml  |
 | 1.20       | 1.6.0, master | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml  |
 
+## Integration Tests
+
+**Requirements: Docker**
+
+The core operations like publishing and resizing can be tested locally with Docker.
+
+```bash
+go test $(go list ./... | grep integrationtests) -v
+```
+
 ## E2E Tests
 
 The Hetzner Cloud CSI Driver was tested against the official k8s e2e

--- a/api/volume.go
+++ b/api/volume.go
@@ -30,14 +30,12 @@ func (s *VolumeService) Create(ctx context.Context, opts volumes.CreateOpts) (*c
 		"volume-name", opts.Name,
 		"volume-size", opts.MinSize,
 		"volume-location", opts.Location,
-		"volume-format", opts.Format,
 	)
 
 	result, _, err := s.client.Volume.Create(ctx, hcloud.VolumeCreateOpts{
 		Name:     opts.Name,
 		Size:     opts.MinSize,
 		Location: &hcloud.Location{Name: opts.Location},
-		Format:   opts.Format,
 	})
 	if err != nil {
 		level.Info(s.logger).Log(

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -48,14 +48,9 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 	}
 
 	// Check if ALL volume capabilities are supported.
-	var fsType *string
 	for i, cap := range req.VolumeCapabilities {
 		if !isCapabilitySupported(cap) {
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("capability at index %d is not supported", i))
-		}
-		// If this volume is destined to have a filesystem on it, we can pass that information along to hcloud API.
-		if mount := cap.GetMount(); mount != nil {
-			fsType = &mount.FsType
 		}
 	}
 
@@ -73,7 +68,6 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 		MinSize:  minSize,
 		MaxSize:  maxSize,
 		Location: location,
-		Format:   fsType,
 	})
 	if err != nil {
 		level.Error(s.logger).Log(

--- a/driver/node_test.go
+++ b/driver/node_test.go
@@ -47,7 +47,7 @@ func newNodeServerTestEnv() nodeServiceTestEnv {
 func TestNodeServiceNodePublishVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.PublishFunc = func(targetPath string, devicePath string, opts volumes.MountOpts) error {
+	env.volumeMountService.PublishFunc = func(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path passed to volume service: %s", targetPath)
 		}
@@ -84,7 +84,7 @@ func TestNodeServiceNodePublishBlockVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
 	env.volumeMountService.PublishFunc = func(
-		targetPath, devicePath string, opts volumes.MountOpts,
+		volumeID string, targetPath, devicePath string, encryptionPassphrase string, opts volumes.MountOpts,
 	) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path: %s", targetPath)
@@ -117,7 +117,7 @@ func TestNodeServiceNodePublishBlockVolume(t *testing.T) {
 func TestNodeServiceNodePublishPublishError(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.PublishFunc = func(targetPath string, devicePath string, opts volumes.MountOpts) error {
+	env.volumeMountService.PublishFunc = func(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
 		return io.EOF
 	}
 
@@ -213,7 +213,7 @@ func TestNodeServiceNodePublishVolumeInputErrors(t *testing.T) {
 func TestNodeServiceNodeUnpublishVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.UnpublishFunc = func(targetPath string) error {
+	env.volumeMountService.UnpublishFunc = func(volumeID string, targetPath string) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path passed to volume service: %s", targetPath)
 		}
@@ -232,7 +232,7 @@ func TestNodeServiceNodeUnpublishVolume(t *testing.T) {
 func TestNodeServiceNodeUnpublishUnpublishError(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.UnpublishFunc = func(targetPath string) error {
+	env.volumeMountService.UnpublishFunc = func(volumeID string, targetPath string) error {
 		return io.EOF
 	}
 
@@ -333,7 +333,7 @@ func TestNodeServiceNodeExpandVolume(t *testing.T) {
 		}
 		return true, nil
 	}
-	env.volumeResizeService.ResizeFunc = func(volumePath string) error {
+	env.volumeResizeService.ResizeFunc = func(volumeID string, volumePath string) error {
 		if volumePath != "volumePath" {
 			t.Errorf("unexpected volume path passed to volume service: %s", volumePath)
 		}
@@ -358,7 +358,7 @@ func TestNodeServiceNodeExpandBlockVolume(t *testing.T) {
 		}
 		return true, nil
 	}
-	env.volumeResizeService.ResizeFunc = func(volumePath string) error {
+	env.volumeResizeService.ResizeFunc = func(volumeID string, volumePath string) error {
 		t.Errorf("This function should never be called.")
 		return nil
 	}

--- a/driver/node_test.go
+++ b/driver/node_test.go
@@ -47,7 +47,7 @@ func newNodeServerTestEnv() nodeServiceTestEnv {
 func TestNodeServiceNodePublishVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.PublishFunc = func(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
+	env.volumeMountService.PublishFunc = func(targetPath string, devicePath string, opts volumes.MountOpts) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path passed to volume service: %s", targetPath)
 		}
@@ -84,7 +84,7 @@ func TestNodeServiceNodePublishBlockVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
 	env.volumeMountService.PublishFunc = func(
-		volumeID string, targetPath, devicePath string, encryptionPassphrase string, opts volumes.MountOpts,
+		targetPath, devicePath string, opts volumes.MountOpts,
 	) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path: %s", targetPath)
@@ -117,7 +117,7 @@ func TestNodeServiceNodePublishBlockVolume(t *testing.T) {
 func TestNodeServiceNodePublishPublishError(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.PublishFunc = func(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
+	env.volumeMountService.PublishFunc = func(targetPath string, devicePath string, opts volumes.MountOpts) error {
 		return io.EOF
 	}
 
@@ -213,7 +213,7 @@ func TestNodeServiceNodePublishVolumeInputErrors(t *testing.T) {
 func TestNodeServiceNodeUnpublishVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.UnpublishFunc = func(volumeID string, targetPath string) error {
+	env.volumeMountService.UnpublishFunc = func(targetPath string) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path passed to volume service: %s", targetPath)
 		}
@@ -232,7 +232,7 @@ func TestNodeServiceNodeUnpublishVolume(t *testing.T) {
 func TestNodeServiceNodeUnpublishUnpublishError(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.UnpublishFunc = func(volumeID string, targetPath string) error {
+	env.volumeMountService.UnpublishFunc = func(targetPath string) error {
 		return io.EOF
 	}
 
@@ -333,7 +333,7 @@ func TestNodeServiceNodeExpandVolume(t *testing.T) {
 		}
 		return true, nil
 	}
-	env.volumeResizeService.ResizeFunc = func(volumeID string, volumePath string) error {
+	env.volumeResizeService.ResizeFunc = func(volumePath string) error {
 		if volumePath != "volumePath" {
 			t.Errorf("unexpected volume path passed to volume service: %s", volumePath)
 		}
@@ -358,7 +358,7 @@ func TestNodeServiceNodeExpandBlockVolume(t *testing.T) {
 		}
 		return true, nil
 	}
-	env.volumeResizeService.ResizeFunc = func(volumeID string, volumePath string) error {
+	env.volumeResizeService.ResizeFunc = func(volumePath string) error {
 		t.Errorf("This function should never be called.")
 		return nil
 	}

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -192,6 +192,14 @@ func (s *sanityMountService) PathExists(path string) (bool, error) {
 	return true, nil
 }
 
+func (s *sanityMountService) FormatDisk(disk string, fstype string) error {
+	return nil
+}
+
+func (s *sanityMountService) DetectDiskFormat(disk string) (string, error) {
+	return "ext4", nil
+}
+
 type sanityResizeService struct{}
 
 func (s *sanityResizeService) Resize(volumePath string) error {

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -177,11 +177,11 @@ func (s *sanityVolumeService) Detach(ctx context.Context, volume *csi.Volume, se
 
 type sanityMountService struct{}
 
-func (s *sanityMountService) Publish(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
+func (s *sanityMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
 	return nil
 }
 
-func (s *sanityMountService) Unpublish(volumeID string, targetPath string) error {
+func (s *sanityMountService) Unpublish(targetPath string) error {
 	return nil
 }
 
@@ -194,7 +194,7 @@ func (s *sanityMountService) PathExists(path string) (bool, error) {
 
 type sanityResizeService struct{}
 
-func (s *sanityResizeService) Resize(volumeID string, volumePath string) error {
+func (s *sanityResizeService) Resize(volumePath string) error {
 	return nil
 }
 

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -177,11 +177,11 @@ func (s *sanityVolumeService) Detach(ctx context.Context, volume *csi.Volume, se
 
 type sanityMountService struct{}
 
-func (s *sanityMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
+func (s *sanityMountService) Publish(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
 	return nil
 }
 
-func (s *sanityMountService) Unpublish(targetPath string) error {
+func (s *sanityMountService) Unpublish(volumeID string, targetPath string) error {
 	return nil
 }
 
@@ -194,7 +194,7 @@ func (s *sanityMountService) PathExists(path string) (bool, error) {
 
 type sanityResizeService struct{}
 
-func (s *sanityResizeService) Resize(volumePath string) error {
+func (s *sanityResizeService) Resize(volumeID string, volumePath string) error {
 	return nil
 }
 

--- a/e2etests/testing.go
+++ b/e2etests/testing.go
@@ -104,7 +104,7 @@ func (tc *TestCluster) initialize() error {
 	}
 	if buildImage {
 		fmt.Printf("%s: Building image\n", op)
-		if _, err := integrationtests.DockerBuild(imageName, "../", "Dockerfile"); err != nil {
+		if _, err := integrationtests.DockerBuild(imageName, "../"); err != nil {
 			return fmt.Errorf("%s: %v", op, err)
 		}
 	}

--- a/e2etests/testing.go
+++ b/e2etests/testing.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/hetznercloud/csi-driver/integrationtests"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,13 +104,13 @@ func (tc *TestCluster) initialize() error {
 	}
 	if buildImage {
 		fmt.Printf("%s: Building image\n", op)
-		if err := runCmd("docker", []string{"build", "-t", imageName, "../"}, nil); err != nil {
+		if _, err := integrationtests.DockerBuild(imageName, "../", "Dockerfile"); err != nil {
 			return fmt.Errorf("%s: %v", op, err)
 		}
 	}
 
 	fmt.Printf("%s: Saving image to disk\n", op)
-	if err := runCmd("docker", []string{"save", "--output", "ci-hcloud-csi-driver.tar", imageName}, nil); err != nil {
+	if _, err := integrationtests.DockerSave(imageName, "ci-hcloud-csi-driver.tar"); err != nil {
 		return fmt.Errorf("%s: %v", op, err)
 	}
 

--- a/integrationtests/.gitignore
+++ b/integrationtests/.gitignore
@@ -1,0 +1,1 @@
+integrationtests.tests

--- a/integrationtests/Dockerfile
+++ b/integrationtests/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.13
+
+RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra btrfs-progs cryptsetup
+RUN apk add --no-cache coreutils
+
+WORKDIR /test
+COPY integrationtests.tests /test/integrationtests.tests
+ENTRYPOINT ["/test/integrationtests.tests"]

--- a/integrationtests/cryptsetup_test.go
+++ b/integrationtests/cryptsetup_test.go
@@ -1,0 +1,54 @@
+package integrationtests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/hetznercloud/csi-driver/volumes"
+)
+
+func TestCryptSetup(t *testing.T) {
+	if !runTestInDockerImage(t, true) {
+		return
+	}
+
+	logger := log.NewLogfmtLogger(NewTestingWriter(t))
+	cryptSetup := volumes.NewCryptSetup(logger)
+	name := "fake"
+	device, err := createFakeDevice(name, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passphrase := "passphrase"
+
+	if err := cryptSetup.Format(device, passphrase); err != nil {
+		t.Fatal(err)
+	}
+	decryptedName := name + "-decrypted"
+
+	if err := cryptSetup.Open(device, decryptedName, passphrase); err != nil {
+		t.Fatal(err)
+	}
+	decryptedDevice := "/dev/mapper/" + decryptedName
+	defer runCmd("cryptsetup", "luksClose", decryptedName)
+
+	if _, err := runCmd("mkfs.ext4", decryptedDevice); err != nil {
+		t.Fatal(err)
+	}
+	decryptedMount := "/mnt/" + name
+	if err := os.MkdirAll(decryptedMount, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCmd("mount", "-t", "ext4", decryptedDevice, decryptedMount); err != nil {
+		t.Fatal(err)
+	}
+	defer runCmd("umount", decryptedMount)
+
+	if _, err := runCmd("umount", decryptedMount); err != nil {
+		t.Fatal(err)
+	}
+	if err := cryptSetup.Close(decryptedName); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integrationtests/docker.go
+++ b/integrationtests/docker.go
@@ -1,0 +1,57 @@
+package integrationtests
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const dockerExecutable = "docker"
+
+func DockerBuild(imageName string, dir string, dockerfile string) (string, error) {
+	dockerArgs := []string{"build"}
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		dockerArgs = []string{"buildx", "build", "--platform=linux/amd64"}
+	}
+	if dockerfile != "" {
+		dockerArgs = append(dockerArgs, "-f", dockerfile)
+	}
+	dockerArgs = append(dockerArgs, "-t", imageName, dir)
+	return runCmd(dockerExecutable, dockerArgs...)
+}
+
+func DockerSave(imageName string, output string) (string, error) {
+	dockerArgs := []string{"save", "--output", output, imageName}
+	return runCmd(dockerExecutable, dockerArgs...)
+}
+
+func DockerRun(imageName string, envs []string, argv []string, privileged bool) (string, error) {
+	dockerArgs := []string{"run", "--rm"}
+	for _, env := range envs {
+		dockerArgs = append(dockerArgs, "-e", env)
+	}
+	if privileged {
+		dockerArgs = append(dockerArgs, "--privileged")
+	}
+	dockerArgs = append(dockerArgs, imageName)
+	dockerArgs = append(dockerArgs, argv...)
+	return runCmd(dockerExecutable, dockerArgs...)
+}
+
+func runCmd(name string, args ...string) (string, error) {
+	return runCmdWithStdin("", name, args...)
+}
+
+func runCmdWithStdin(stdin string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	outputBytes, err := cmd.CombinedOutput()
+	output := string(outputBytes)
+	if err != nil {
+		return output, fmt.Errorf("run command %s failed: %w\n%s", strings.Join(append([]string{name}, args...), " "), err, output)
+	}
+	return output, nil
+}

--- a/integrationtests/docker.go
+++ b/integrationtests/docker.go
@@ -9,13 +9,10 @@ import (
 
 const dockerExecutable = "docker"
 
-func DockerBuild(imageName string, dir string, dockerfile string) (string, error) {
+func DockerBuild(imageName string, dir string) (string, error) {
 	dockerArgs := []string{"build"}
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
-		dockerArgs = []string{"buildx", "build", "--platform=linux/amd64"}
-	}
-	if dockerfile != "" {
-		dockerArgs = append(dockerArgs, "-f", dockerfile)
+		dockerArgs = []string{"buildx", "build", "--platform=linux/amd64", "--load"}
 	}
 	dockerArgs = append(dockerArgs, "-t", imageName, dir)
 	return runCmd(dockerExecutable, dockerArgs...)

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -96,6 +96,8 @@ func NewTestingWriter(t *testing.T) TestingWriter {
 }
 
 func (w TestingWriter) Write(p []byte) (n int, err error) {
-	w.t.Log(string(p))
+	if os.Getenv("TEST_DEBUG_MODE") != "" {
+		w.t.Log(string(p))
+	}
 	return len(p), nil
 }

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -31,7 +31,7 @@ func prepareDockerImage() error {
 		os.Exit(1)
 	}
 
-	if output, err := DockerBuild(testImageName, ".", "Dockerfile"); err != nil {
+	if output, err := DockerBuild(testImageName, "."); err != nil {
 		fmt.Printf("Error building docker image: %v\n%s\n", err, output)
 		os.Exit(1)
 	}

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -1,0 +1,101 @@
+package integrationtests
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+const testImageName = "hcloud-csi-driver-integrationtests"
+const testImageEnvironmentVariable = "HCLOUD_CSI_DRIVER_INTEGRATIONTESTS"
+
+func TestMain(t *testing.M) {
+	if os.Getenv(testImageEnvironmentVariable) != "true" {
+		prepareDockerImage()
+	}
+
+	os.Exit(t.Run())
+}
+
+func prepareDockerImage() error {
+	os.Setenv("GOOS", "linux")
+	defer os.Unsetenv("GOOS")
+	os.Setenv("GOARCH", "amd64")
+	defer os.Unsetenv("GOARCH")
+	os.Setenv("CGO_ENABLED", "0")
+	defer os.Unsetenv("CGO_ENABLED")
+	if output, err := runCmd("go", "test", ".", "-c", "-o", "integrationtests.tests"); err != nil {
+		fmt.Printf("Error compiling test binary: %v\n%s\n", err, output)
+		os.Exit(1)
+	}
+
+	if output, err := DockerBuild(testImageName, ".", "Dockerfile"); err != nil {
+		fmt.Printf("Error building docker image: %v\n%s\n", err, output)
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+func runTestInDockerImage(t *testing.T, privileged bool) bool {
+	if os.Getenv(testImageEnvironmentVariable) == "true" {
+		return true
+	}
+
+	if output, err := DockerRun(testImageName, []string{testImageEnvironmentVariable + "=true"}, []string{"-test.v", "-test.run", t.Name()}, privileged); err != nil {
+		err := fmt.Errorf("Error running test in docker image: %w\n%s\n", err, output)
+		t.Fatal(err)
+	} else {
+		t.Log(output)
+	}
+
+	return false
+}
+
+func createFakeDevice(name string, megabytes int) (string, error) {
+	path := "/dev-" + name
+	if _, err := os.Create(path); err != nil {
+		return "", err
+	}
+	if _, err := runCmd("dd", "if=/dev/zero", "of="+path, "bs=1M", "count="+strconv.Itoa(megabytes)); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func increaseFakeDeviceSize(name string, megabytesToAdd int) error {
+	path := "/dev-" + name
+	if _, err := runCmd("dd", "if=/dev/zero", "of="+path, "bs=1M", "count="+strconv.Itoa(megabytesToAdd), "oflag=append", "conv=notrunc"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getFakeDeviceSizeKilobytes(mountPoint string) (int, error) {
+	if output, err := runCmd("df", "--output=size", "-k", mountPoint); err != nil {
+		return -1, err
+	} else {
+		regex := regexp.MustCompile(`(?ms)^\s*1K-blocks\s*(\d+)\s*$`)
+		match := regex.FindStringSubmatch(output)
+		if match == nil {
+			return -1, fmt.Errorf("unexpected df command output")
+		}
+		size, _ := strconv.Atoi(match[1])
+		return size, nil
+	}
+}
+
+type TestingWriter struct {
+	t *testing.T
+}
+
+func NewTestingWriter(t *testing.T) TestingWriter {
+	return TestingWriter{t: t}
+}
+
+func (w TestingWriter) Write(p []byte) (n int, err error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}

--- a/integrationtests/volumes_test.go
+++ b/integrationtests/volumes_test.go
@@ -1,0 +1,149 @@
+package integrationtests
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/hetznercloud/csi-driver/volumes"
+)
+
+func TestVolumePublishUnpublish(t *testing.T) {
+	if !runTestInDockerImage(t, true) {
+		return
+	}
+
+	tests := []struct {
+		name       string
+		passphrase string
+	}{
+		{"plain", ""},
+		{"encrypted", "passphrase"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := log.NewLogfmtLogger(NewTestingWriter(t))
+			mountService := volumes.NewLinuxMountService(logger)
+			device, err := createFakeDevice("fake-"+test.name, 32)
+			if err != nil {
+				t.Fatal(err)
+			}
+			volumeID := "123"
+			targetPath, err := ioutil.TempDir(os.TempDir(), "")
+			if err != nil {
+				t.Fatal()
+			}
+
+			if err := mountService.Publish(volumeID, targetPath, device, test.passphrase, volumes.MountOpts{}); err != nil {
+				t.Fatal(err)
+			}
+			defer mountService.Unpublish(volumeID, targetPath)
+
+			if files, err := ioutil.ReadDir(targetPath); err != nil {
+				t.Fatal(err)
+			} else {
+				if len(files) != 1 || !files[0].IsDir() || files[0].Name() != "lost+found" {
+					t.Fatal("expected an fresh ext4 formatted disk with only lost+found directory")
+				}
+			}
+
+			if err := mountService.Unpublish(volumeID, targetPath); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestVolumeResize(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("online resizing only works under Linux")
+	}
+
+	if !runTestInDockerImage(t, true) {
+		return
+	}
+
+	tests := []*struct {
+		name        string
+		passphrase  string
+		initialSize int
+		finalSize   int
+	}{
+		{"plain", "", 26609, 57317},
+		{"encrypted", "passphrase", 27761, 58597},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := log.NewLogfmtLogger(NewTestingWriter(t))
+			mountService := volumes.NewLinuxMountService(logger)
+			resizeService := volumes.NewLinuxResizeService(logger)
+			cryptSetup := volumes.NewCryptSetup(logger)
+			deviceName := "fake-" + test.name
+			device, err := createFakeDevice(deviceName, 32)
+			if err != nil {
+				t.Fatal(err)
+			}
+			volumeID := "123"
+			targetPath, err := ioutil.TempDir(os.TempDir(), "")
+			if err != nil {
+				t.Fatal()
+			}
+
+			if test.passphrase == "" {
+				if _, err := runCmd("mkfs.ext4", device); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				decryptedName := test.name + "-decrypted"
+				if err := cryptSetup.Format(device, test.passphrase); err != nil {
+					t.Fatal()
+				}
+				if err := cryptSetup.Open(device, decryptedName, test.passphrase); err != nil {
+					t.Fatal()
+				}
+				defer cryptSetup.Close(decryptedName)
+				decryptedDevice := "/dev/mapper/" + decryptedName
+				if _, err := runCmd("mkfs.ext4", decryptedDevice); err != nil {
+					t.Fatal(err)
+				}
+				if err := cryptSetup.Close(decryptedName); err != nil {
+					t.Fatal(t)
+				}
+			}
+
+			if err := increaseFakeDeviceSize(deviceName, 32); err != nil {
+				t.Fatal()
+			}
+
+			if err := mountService.Publish(volumeID, targetPath, device, test.passphrase, volumes.MountOpts{}); err != nil {
+				t.Fatal(err)
+			}
+			defer mountService.Unpublish(volumeID, targetPath)
+
+			if size, err := getFakeDeviceSizeKilobytes(targetPath); err != nil {
+				t.Fatal(t)
+			} else if size != test.initialSize {
+				t.Error(fmt.Errorf("expected initial size of %d KB, got %d KB", test.initialSize, size))
+			}
+
+			if err := resizeService.Resize(volumeID, targetPath); err != nil {
+				t.Fatal(err)
+			}
+
+			if size, err := getFakeDeviceSizeKilobytes(targetPath); err != nil {
+				t.Fatal(t)
+			} else if size != test.finalSize {
+				t.Fatal(fmt.Errorf("expected final size of %d KB, got %d KB", test.finalSize, size))
+			}
+
+			if err := mountService.Unpublish(volumeID, targetPath); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/integrationtests/volumes_test.go
+++ b/integrationtests/volumes_test.go
@@ -112,7 +112,7 @@ func TestVolumeResize(t *testing.T) {
 					t.Fatal(err)
 				}
 				if err := cryptSetup.Close(decryptedName); err != nil {
-					t.Fatal(t)
+					t.Fatal(err)
 				}
 			}
 
@@ -128,7 +128,7 @@ func TestVolumeResize(t *testing.T) {
 			defer mountService.Unpublish(targetPath)
 
 			if size, err := getFakeDeviceSizeKilobytes(targetPath); err != nil {
-				t.Fatal(t)
+				t.Fatal(err)
 			} else if size != test.initialSize {
 				t.Error(fmt.Errorf("expected initial size of %d KB, got %d KB", test.initialSize, size))
 			}
@@ -138,7 +138,7 @@ func TestVolumeResize(t *testing.T) {
 			}
 
 			if size, err := getFakeDeviceSizeKilobytes(targetPath); err != nil {
-				t.Fatal(t)
+				t.Fatal(err)
 			} else if size != test.finalSize {
 				t.Fatal(fmt.Errorf("expected final size of %d KB, got %d KB", test.finalSize, size))
 			}

--- a/integrationtests/volumes_test.go
+++ b/integrationtests/volumes_test.go
@@ -32,16 +32,17 @@ func TestVolumePublishUnpublish(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			volumeID := "123"
 			targetPath, err := ioutil.TempDir(os.TempDir(), "")
 			if err != nil {
 				t.Fatal()
 			}
 
-			if err := mountService.Publish(volumeID, targetPath, device, test.passphrase, volumes.MountOpts{}); err != nil {
+			if err := mountService.Publish(targetPath, device, volumes.MountOpts{
+				EncryptionPassphrase: test.passphrase,
+			}); err != nil {
 				t.Fatal(err)
 			}
-			defer mountService.Unpublish(volumeID, targetPath)
+			defer mountService.Unpublish(targetPath)
 
 			if files, err := ioutil.ReadDir(targetPath); err != nil {
 				t.Fatal(err)
@@ -51,7 +52,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 				}
 			}
 
-			if err := mountService.Unpublish(volumeID, targetPath); err != nil {
+			if err := mountService.Unpublish(targetPath); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -88,7 +89,6 @@ func TestVolumeResize(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			volumeID := "123"
 			targetPath, err := ioutil.TempDir(os.TempDir(), "")
 			if err != nil {
 				t.Fatal()
@@ -120,10 +120,12 @@ func TestVolumeResize(t *testing.T) {
 				t.Fatal()
 			}
 
-			if err := mountService.Publish(volumeID, targetPath, device, test.passphrase, volumes.MountOpts{}); err != nil {
+			if err := mountService.Publish(targetPath, device, volumes.MountOpts{
+				EncryptionPassphrase: test.passphrase,
+			}); err != nil {
 				t.Fatal(err)
 			}
-			defer mountService.Unpublish(volumeID, targetPath)
+			defer mountService.Unpublish(targetPath)
 
 			if size, err := getFakeDeviceSizeKilobytes(targetPath); err != nil {
 				t.Fatal(t)
@@ -131,7 +133,7 @@ func TestVolumeResize(t *testing.T) {
 				t.Error(fmt.Errorf("expected initial size of %d KB, got %d KB", test.initialSize, size))
 			}
 
-			if err := resizeService.Resize(volumeID, targetPath); err != nil {
+			if err := resizeService.Resize(targetPath); err != nil {
 				t.Fatal(err)
 			}
 
@@ -141,7 +143,7 @@ func TestVolumeResize(t *testing.T) {
 				t.Fatal(fmt.Errorf("expected final size of %d KB, got %d KB", test.finalSize, size))
 			}
 
-			if err := mountService.Unpublish(volumeID, targetPath); err != nil {
+			if err := mountService.Unpublish(targetPath); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -70,16 +70,16 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 }
 
 type VolumeMountService struct {
-	PublishFunc    func(targetPath string, devicePath string, opts volumes.MountOpts) error
-	UnpublishFunc  func(targetPath string) error
+	PublishFunc    func(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error
+	UnpublishFunc  func(volumeID string, targetPath string) error
 	PathExistsFunc func(path string) (bool, error)
 }
 
-func (s *VolumeMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
+func (s *VolumeMountService) Publish(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
 	if s.PublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.PublishFunc(targetPath, devicePath, opts)
+	return s.PublishFunc(volumeID, targetPath, devicePath, encryptionPassphrase, opts)
 }
 
 func (s *VolumeMountService) PathExists(path string) (bool, error) {
@@ -89,22 +89,22 @@ func (s *VolumeMountService) PathExists(path string) (bool, error) {
 	return s.PathExistsFunc(path)
 }
 
-func (s *VolumeMountService) Unpublish(targetPath string) error {
+func (s *VolumeMountService) Unpublish(volumeID string, targetPath string) error {
 	if s.UnpublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.UnpublishFunc(targetPath)
+	return s.UnpublishFunc(volumeID, targetPath)
 }
 
 type VolumeResizeService struct {
-	ResizeFunc func(volumePath string) error
+	ResizeFunc func(volumeID string, volumePath string) error
 }
 
-func (s *VolumeResizeService) Resize(volumePath string) error {
+func (s *VolumeResizeService) Resize(volumeID string, volumePath string) error {
 	if s.ResizeFunc == nil {
 		panic("not implemented")
 	}
-	return s.ResizeFunc(volumePath)
+	return s.ResizeFunc(volumeID, volumePath)
 }
 
 type VolumeStatsService struct {

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -70,16 +70,16 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 }
 
 type VolumeMountService struct {
-	PublishFunc    func(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error
-	UnpublishFunc  func(volumeID string, targetPath string) error
+	PublishFunc    func(targetPath string, devicePath string, opts volumes.MountOpts) error
+	UnpublishFunc  func(targetPath string) error
 	PathExistsFunc func(path string) (bool, error)
 }
 
-func (s *VolumeMountService) Publish(volumeID string, targetPath string, devicePath string, encryptionPassphrase string, opts volumes.MountOpts) error {
+func (s *VolumeMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
 	if s.PublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.PublishFunc(volumeID, targetPath, devicePath, encryptionPassphrase, opts)
+	return s.PublishFunc(targetPath, devicePath, opts)
 }
 
 func (s *VolumeMountService) PathExists(path string) (bool, error) {
@@ -89,22 +89,22 @@ func (s *VolumeMountService) PathExists(path string) (bool, error) {
 	return s.PathExistsFunc(path)
 }
 
-func (s *VolumeMountService) Unpublish(volumeID string, targetPath string) error {
+func (s *VolumeMountService) Unpublish(targetPath string) error {
 	if s.UnpublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.UnpublishFunc(volumeID, targetPath)
+	return s.UnpublishFunc(targetPath)
 }
 
 type VolumeResizeService struct {
-	ResizeFunc func(volumeID string, volumePath string) error
+	ResizeFunc func(volumePath string) error
 }
 
-func (s *VolumeResizeService) Resize(volumeID string, volumePath string) error {
+func (s *VolumeResizeService) Resize(volumePath string) error {
 	if s.ResizeFunc == nil {
 		panic("not implemented")
 	}
-	return s.ResizeFunc(volumeID, volumePath)
+	return s.ResizeFunc(volumePath)
 }
 
 type VolumeStatsService struct {

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -70,9 +70,11 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 }
 
 type VolumeMountService struct {
-	PublishFunc    func(targetPath string, devicePath string, opts volumes.MountOpts) error
-	UnpublishFunc  func(targetPath string) error
-	PathExistsFunc func(path string) (bool, error)
+	PublishFunc          func(targetPath string, devicePath string, opts volumes.MountOpts) error
+	UnpublishFunc        func(targetPath string) error
+	PathExistsFunc       func(path string) (bool, error)
+	FormatDiskFunc       func(disk string, fstype string) error
+	DetectDiskFormatFunc func(disk string) (string, error)
 }
 
 func (s *VolumeMountService) Publish(targetPath string, devicePath string, opts volumes.MountOpts) error {
@@ -94,6 +96,20 @@ func (s *VolumeMountService) Unpublish(targetPath string) error {
 		panic("not implemented")
 	}
 	return s.UnpublishFunc(targetPath)
+}
+
+func (s *VolumeMountService) FormatDisk(disk string, fstype string) error {
+	if s.FormatDiskFunc == nil {
+		panic("not implemented")
+	}
+	return s.FormatDiskFunc(disk, fstype)
+}
+
+func (s *VolumeMountService) DetectDiskFormat(disk string) (string, error) {
+	if s.DetectDiskFormatFunc == nil {
+		panic("not implemented")
+	}
+	return s.DetectDiskFormatFunc(disk)
 }
 
 type VolumeResizeService struct {

--- a/volumes/cryptsetup.go
+++ b/volumes/cryptsetup.go
@@ -1,0 +1,142 @@
+package volumes
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+const cryptsetupExecuable = "cryptsetup"
+
+type CryptSetup struct {
+	logger log.Logger
+}
+
+func (cs *CryptSetup) IsFormatted(devicePath string) (bool, error) {
+	output, code, err := command(cryptsetupExecuable, "isLuks", devicePath)
+	if err != nil {
+		if code == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to check LUKS device %s formatting status: %s", devicePath, output)
+	}
+	return true, nil
+}
+
+func (cs *CryptSetup) IsActive(luksDeviceName string) (bool, error) {
+	output, code, err := command(cryptsetupExecuable, "status", luksDeviceName)
+	if err != nil {
+		if code == 4 {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to check LUKS device %s activity: %s", luksDeviceName, output)
+	}
+	return true, nil
+}
+
+func (cs *CryptSetup) FormatSafe(devicePath string, passphrase string) error {
+	isFormatted, err := cs.IsFormatted(devicePath)
+	if err != nil {
+		return err
+	}
+	if isFormatted {
+		return nil
+	}
+
+	if err := cs.Format(devicePath, passphrase); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cs *CryptSetup) Format(devicePath string, passphrase string) error {
+	level.Info(cs.logger).Log(
+		"msg", "formatting LUKS device",
+		"devicePath", devicePath,
+	)
+	output, _, err := commandWithStdin(passphrase, cryptsetupExecuable, "luksFormat", "--type", "luks1", devicePath)
+	if err != nil {
+		return fmt.Errorf("unable to format device %s with LUKS: %s", devicePath, output)
+	}
+	return nil
+}
+
+func (cs *CryptSetup) Open(devicePath string, luksDeviceName string, passphrase string) error {
+	active, err := cs.IsActive(luksDeviceName)
+	if err != nil {
+		return err
+	}
+	if active {
+		return nil
+	}
+	level.Info(cs.logger).Log(
+		"msg", "opening LUKS device",
+		"devicePath", devicePath,
+		"luksDeviceName", luksDeviceName,
+	)
+	output, _, err := commandWithStdin(passphrase, cryptsetupExecuable, "luksOpen", devicePath, luksDeviceName)
+	if err != nil {
+		return fmt.Errorf("unable to open LUKS device %s: %s", devicePath, output)
+	}
+	return nil
+}
+
+func (cs *CryptSetup) Close(luksDeviceName string) error {
+	active, err := cs.IsActive(luksDeviceName)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return nil
+	}
+	level.Info(cs.logger).Log(
+		"msg", "closing LUKS device",
+		"luksDeviceName", luksDeviceName,
+	)
+	output, _, err := command(cryptsetupExecuable, "luksClose", luksDeviceName)
+	if err != nil {
+		return fmt.Errorf("unable to close LUKS device %s: %s", luksDeviceName, output)
+	}
+	return nil
+}
+
+func (cs *CryptSetup) Resize(luksDeviceName string) error {
+	level.Info(cs.logger).Log(
+		"msg", "resizing LUKS device",
+		"luksDeviceName", luksDeviceName,
+	)
+	output, _, err := command(cryptsetupExecuable, "resize", luksDeviceName)
+	if err != nil {
+		return fmt.Errorf("unable to resize LUKS device %s: %s", luksDeviceName, output)
+	}
+	return nil
+}
+
+func GenerateLUKSDevicePath(luksDeviceName string) string {
+	return "/dev/mapper/" + luksDeviceName
+}
+
+func command(name string, args ...string) (string, int, error) {
+	return commandWithStdin("", name, args...)
+}
+
+func commandWithStdin(stdin string, name string, args ...string) (string, int, error) {
+	cmd := exec.Command(name, args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	outputBytes, err := cmd.CombinedOutput()
+	output := string(outputBytes)
+	if err != nil {
+		exitError, ok := err.(*exec.ExitError)
+		if !ok {
+			return output, 0, err
+		}
+		return output, exitError.ExitCode(), exitError
+	}
+	return output, 0, nil
+}

--- a/volumes/cryptsetup.go
+++ b/volumes/cryptsetup.go
@@ -15,6 +15,10 @@ type CryptSetup struct {
 	logger log.Logger
 }
 
+func NewCryptSetup(logger log.Logger) *CryptSetup {
+	return &CryptSetup{logger: logger}
+}
+
 func (cs *CryptSetup) IsFormatted(devicePath string) (bool, error) {
 	output, code, err := command(cryptsetupExecuable, "isLuks", devicePath)
 	if err != nil {

--- a/volumes/cryptsetup.go
+++ b/volumes/cryptsetup.go
@@ -120,6 +120,11 @@ func (cs *CryptSetup) Resize(luksDeviceName string) error {
 	return nil
 }
 
+func GenerateLUKSDeviceName(devicePath string) string {
+	segments := strings.Split(devicePath, "/")
+	return segments[len(segments)-1]
+}
+
 func GenerateLUKSDevicePath(luksDeviceName string) string {
 	return "/dev/mapper/" + luksDeviceName
 }

--- a/volumes/idempotency.go
+++ b/volumes/idempotency.go
@@ -29,7 +29,6 @@ func (s *IdempotentService) Create(ctx context.Context, opts CreateOpts) (*csi.V
 		"min-size", opts.MinSize,
 		"max-size", opts.MaxSize,
 		"location", opts.Location,
-		"format", opts.Format,
 	)
 
 	volume, err := s.volumeService.Create(ctx, opts)

--- a/volumes/mount.go
+++ b/volumes/mount.go
@@ -42,9 +42,7 @@ func NewLinuxMountService(logger log.Logger) *LinuxMountService {
 			Interface: mount.New(""),
 			Exec:      exec.New(),
 		},
-		cryptSetup: &CryptSetup{
-			logger: logger,
-		},
+		cryptSetup: NewCryptSetup(logger),
 	}
 }
 

--- a/volumes/mount.go
+++ b/volumes/mount.go
@@ -67,6 +67,9 @@ func (s *LinuxMountService) Publish(targetPath string, devicePath string, opts M
 	if !isNotMountPoint {
 		return nil
 	}
+	if opts.FSType == "" {
+		opts.FSType = DefaultFSType
+	}
 	targetPathPermissions := os.FileMode(0750)
 	if opts.BlockVolume {
 		mountOptions = append(mountOptions, "bind")
@@ -81,9 +84,6 @@ func (s *LinuxMountService) Publish(targetPath string, devicePath string, opts M
 		}
 		_ = mountFile.Close()
 	} else {
-		if opts.FSType == "" {
-			opts.FSType = DefaultFSType
-		}
 		if err := os.MkdirAll(targetPath, targetPathPermissions); err != nil {
 			return err
 		}

--- a/volumes/resize.go
+++ b/volumes/resize.go
@@ -29,9 +29,7 @@ func NewLinuxResizeService(logger log.Logger) *LinuxResizeService {
 			Interface: mount.New(""),
 			Exec:      exec.New(),
 		}.Exec),
-		cryptSetup: &CryptSetup{
-			logger: logger,
-		},
+		cryptSetup: NewCryptSetup(logger),
 	}
 }
 

--- a/volumes/service.go
+++ b/volumes/service.go
@@ -33,5 +33,4 @@ type CreateOpts struct {
 	MinSize  int
 	MaxSize  int
 	Location string
-	Format   *string
 }


### PR DESCRIPTION
This PR adds full volume encryption. In short, one just has to add a new storage class referencing an encryption passphrase:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: encryption-secret
  namespace: kube-system
stringData:
  encryption-passphrase: foobar

--- 

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: hcloud-volumes-encrypted
provisioner: csi.hetzner.cloud
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
allowVolumeExpansion: true
parameters:
  csi.storage.k8s.io/node-publish-secret-name: encryption-secret
  csi.storage.k8s.io/node-publish-secret-namespace: kube-system
```

~~What is still missing is adjusting the e2e tests to also cover this (or do they already cover that case)?~~

Solves #40 and #163.

Note: ~~I did not make the PR against the latest `master`, as I had issues with it (the availability zone request [here](https://github.com/hetznercloud/csi-driver/blob/master/cmd/node/main.go#L33) returns HTTP 404 on my Hetzner test K8s cluster and hence the csi-node wouldn't start up). I also created a PR for that issue: https://github.com/hetznercloud/hcloud-go/issues/192.
If this feature would be accepted in general, I am happy to update the PR to fit into the master.~~