### PR TITLE
Get the `serverLocation` by using the hcloud client instead of metadata client

### DIFF
--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -322,6 +322,11 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
+        - name: HCLOUD_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: hcloud
         image: hetznercloud/hcloud-csi-driver:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Because older VMs, or VMs created from a snapshot, does not have the `availability-zone` in the metadata service.
So this is a workaround by using the hcloud client to call the hcloud API, and mounts the HCLOUD_TOKEN to the hcloud-csi-node

Related issue https://github.com/hetznercloud/hcloud-go/issues/192? 