### PR TITLE
ci: publish unstable docker image from main

### DIFF
--- a/.github/workflows/publish_on_master.yml
+++ b/.github/workflows/publish_on_master.yml
@@ -2,7 +2,7 @@ name: Push latest version
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix publishing unstable docker images and allow us to experiment with new features (e.g. #304)