### PR TITLE
fix secret name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
    apiVersion: v1
    kind: Secret
    metadata:
-     name: hcloud
+     name: hcloud-csi
      namespace: kube-system
    stringData:
      token: YOURTOKEN


### PR DESCRIPTION
otherwise pods go into `CreateContainerConfigError` due to `Error:secret "hcloud-csi" not found`