### PR TITLE
Build the Docker image on any platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ ADD . /csi/
 RUN ls -al
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o controller.bin github.com/hetznercloud/csi-driver/cmd/controller
-RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o node.bin github.com/hetznercloud/csi-driver/cmd/node
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o controller.bin github.com/hetznercloud/csi-driver/cmd/controller
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o node.bin github.com/hetznercloud/csi-driver/cmd/node
 
-FROM alpine:3.15
+FROM --platform=linux/amd64 alpine:3.15
 RUN apk add --no-cache ca-certificates e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra btrfs-progs cryptsetup
 ENV GOTRACEBACK=all
 COPY --from=builder /csi/controller.bin /bin/hcloud-csi-driver-controller


### PR DESCRIPTION
The resulting Docker image should have the same platform, no matter where it's built.
This change will make sure both the binaries and the base image are always `linux/amd64`.

I also updated the Alpline Linux image to 3.16, as 3.13 is approaching end of support.