### PR TITLE
feat: test against Kubernetes v1.25

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        k8s: [ k8s-1.22.0, k8s-1.23.8, k8s-1.24.2 ]
+        k8s: [ k8s-1.22.15, k8s-1.23.13, k8s-1.24.7, k8s-1.25.3 ]
     name: k8s ${{ matrix.k8s }}
     steps:
     - uses: actions/setup-go@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,14 +37,19 @@ unit:
 k8s 1.22:
   <<: *k8se2e
   variables:
-    K8S_VERSION: k8s-1.22.0
+    K8S_VERSION: k8s-1.22.15
 
 k8s 1.23:
   <<: *k8se2e
   variables:
-    K8S_VERSION: k8s-1.23.8
+    K8S_VERSION: k8s-1.23.13
 
 k8s 1.24:
   <<: *k8se2e
   variables:
-    K8S_VERSION: k8s-1.24.2
+    K8S_VERSION: k8s-1.24.7
+
+k8s 1.25:
+  <<: *k8se2e
+  variables:
+    K8S_VERSION: k8s-1.25.3

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ related only to an unsupported version.
 
 | Kubernetes |    CSI Driver |                                                                                   Deployment File |
 |------------|--------------:|--------------------------------------------------------------------------------------------------:|
+| 1.25       |        main   | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.24       |        main   | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.23       |        main   | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.22       | 1.6.0, main   | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |


### PR DESCRIPTION
Update our tested-against Kubernetes versions to latest versions and add testing for Kubernetes v1.25.

Rebased on #322 to include fixes for integration tests.