### PR TITLE
test: fix integration tests relying on specific byte amounts

### DIFF
--- a/integrationtests/volumes_test.go
+++ b/integrationtests/volumes_test.go
@@ -149,8 +149,8 @@ func TestVolumeResize(t *testing.T) {
 		initialSize int
 		finalSize   int
 	}{
-		{"plain", "", 26609, 57317},
-		{"encrypted", "passphrase", 27761, 58597},
+		{"plain", "", 25844, 56042},
+		{"encrypted", "passphrase", 27044, 57402},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The integration tests for the volume resize feature rely on specific byte amounts that a ext4 filesystem on a fake block device has. The specific amounts recently changed, probably through a new version of mkfs.ext4.

This amount equals the values from our GitHub Actions pipeline, as well as my local machine.

The amounts might need to be changed again in the future if the tests start failing again, we might consider removing tests for the specific amounts, and just check that the resized number is larger than the initial if this happens often.