### PR TITLE
fix: driver version not updated on tagged release

### DIFF
--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -18,10 +18,11 @@ jobs:
           OWNER: ${{ github.repository_owner }}
         run: |
           sed -i -e "s#: .*/hcloud-csi-driver:latest#: $OWNER/hcloud-csi-driver:$RELEASE_VERSION#" deploy/kubernetes/hcloud-csi.yml
+          sed -i -e "s/PluginVersion = \".*\"$/PluginVersion = \"$RELEASE_VERSION\"/g" driver/driver.go
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "Update image tags in hcloud-csi.yml to $RELEASE_VERSION"
+          git commit -m "Update version tags to $RELEASE_VERSION"
           git tag -d v$RELEASE_VERSION
           git tag v$RELEASE_VERSION
           git push origin v$RELEASE_VERSION -f

--- a/script/updateversion.bash
+++ b/script/updateversion.bash
@@ -1,6 +1,0 @@
-#!/bin/bash
-VERSION="$1"
-sed -i "" -e "s/image: hetznercloud\/hcloud-csi-driver:.*$/image: hetznercloud\/hcloud-csi-driver:$VERSION/g" deploy/kubernetes/*.yml
-sed -i "" -e "s/## master/## v$VERSION/g" CHANGES.md
-sed -i "" -e "s/PluginVersion = \".*\"$/PluginVersion = \"$VERSION\"/g" driver/driver.go
-goimports -w driver/driver.go


### PR DESCRIPTION
This version of the driver was not updated on new releases. This causes the user-agent to include the old version.

Concerns this line of code: https://github.com/hetznercloud/csi-driver/blob/main/driver/driver.go#L9