### PR TITLE
fix: invalid topology label on new volumes #333

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -94,7 +94,7 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 			AccessibleTopology: []*proto.Topology{
 				{
 					Segments: map[string]string{
-						TopologySegmentLocation: volume.Location,
+						TopologySegmentLocationLegacy: volume.Location,
 					},
 				},
 			},

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -91,7 +91,7 @@ func TestControllerServiceCreateVolume(t *testing.T) {
 	}
 	if len(resp.Volume.AccessibleTopology) == 1 {
 		top := resp.Volume.AccessibleTopology[0]
-		if loc := top.Segments[TopologySegmentLocation]; loc != "testloc" {
+		if loc := top.Segments[TopologySegmentLocationLegacy]; loc != "testloc" {
 			t.Errorf("unexpected location segment in topology: %s", loc)
 		}
 	} else {
@@ -146,7 +146,7 @@ func TestControllerServiceCreateVolumeWithLocation(t *testing.T) {
 	}
 	if len(resp.Volume.AccessibleTopology) == 1 {
 		top := resp.Volume.AccessibleTopology[0]
-		if loc := top.Segments[TopologySegmentLocation]; loc != "explicit" {
+		if loc := top.Segments[TopologySegmentLocationLegacy]; loc != "explicit" {
 			t.Errorf("unexpected location segment in topology: %s", loc)
 		}
 	} else {


### PR DESCRIPTION
Revert the topology segment label used for new volumes to `csi.hetzner.cloud/location`. Adding the new label was a mistake and leads to incompatibility with the CSI spec (and Nomad).

We plan to fully revert the changes, but that will require user intervention to fix all volumes created with the new label. By changing the label used on new volumes, we can limit the amount of volumes that need to be fixed for users that already upgraded to v2.0.0.

See issue #333 for details.

This is intended for `v2.0.1`