### PR TITLE
fix: revert invalid topology changes #333

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -94,7 +94,7 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 			AccessibleTopology: []*proto.Topology{
 				{
 					Segments: map[string]string{
-						TopologySegmentLocationLegacy: volume.Location,
+						TopologySegmentLocation: volume.Location,
 					},
 				},
 			},

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -91,7 +91,7 @@ func TestControllerServiceCreateVolume(t *testing.T) {
 	}
 	if len(resp.Volume.AccessibleTopology) == 1 {
 		top := resp.Volume.AccessibleTopology[0]
-		if loc := top.Segments[TopologySegmentLocationLegacy]; loc != "testloc" {
+		if loc := top.Segments[TopologySegmentLocation]; loc != "testloc" {
 			t.Errorf("unexpected location segment in topology: %s", loc)
 		}
 	} else {
@@ -146,7 +146,7 @@ func TestControllerServiceCreateVolumeWithLocation(t *testing.T) {
 	}
 	if len(resp.Volume.AccessibleTopology) == 1 {
 		top := resp.Volume.AccessibleTopology[0]
-		if loc := top.Segments[TopologySegmentLocationLegacy]; loc != "explicit" {
+		if loc := top.Segments[TopologySegmentLocation]; loc != "explicit" {
 			t.Errorf("unexpected location segment in topology: %s", loc)
 		}
 	} else {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,9 +1,5 @@
 package driver
 
-import (
-	apiv1 "k8s.io/api/core/v1"
-)
-
 const (
 	PluginName    = "csi.hetzner.cloud"
 	PluginVersion = "1.6.0"
@@ -12,8 +8,5 @@ const (
 	MinVolumeSize     = 10 // GB
 	DefaultVolumeSize = MinVolumeSize
 
-	TopologySegmentLocation = apiv1.LabelZoneRegionStable
-
-	// this label will be deprecated in future releases
-	TopologySegmentLocationLegacy = PluginName + "/location"
+	TopologySegmentLocation = PluginName + "/location"
 )

--- a/driver/node.go
+++ b/driver/node.go
@@ -172,12 +172,7 @@ func (s *NodeService) NodeGetInfo(context.Context, *proto.NodeGetInfoRequest) (*
 		MaxVolumesPerNode: MaxVolumesPerNode,
 		AccessibleTopology: &proto.Topology{
 			Segments: map[string]string{
-				// need this topology key for k8s clusters without hcloud-cloud-controller-manager
-				// that handles this node label
 				TopologySegmentLocation: s.serverLocation,
-				// need this topology key for backward compatibility
-				// for PV created with older version this CSI driver
-				TopologySegmentLocationLegacy: s.serverLocation,
 			},
 		},
 	}


### PR DESCRIPTION
Revert all changes we made to our reported topology for nodes and volumes.

Because we report two segments on the `NodeGetInfo` call, but only one of them on `CreateVolume` we are not compliant with the CSI spec. This did not matter for Kubernetes, because the scheduler still worked, but it breaks Nomad.

As we are not compliant with the CSI spec, we decided to revert these changes, even though it will require user intervention to fix volumes created in the meantime.

For details see issue #333.

This is intended for v2.1.0