### PR TITLE
encrypted storageclass had the wrong names. reference to cryptsetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
    volumeBindingMode: WaitForFirstConsumer
    allowVolumeExpansion: true
    parameters:
-     csi.storage.k8s.io/node-publish-secret-name: encryption
-     csi.storage.k8s.io/node-publish-secret-namespace: default
+     csi.storage.k8s.io/node-publish-secret-name: encryption-secret
+     csi.storage.k8s.io/node-publish-secret-namespace: kube-system
    ```
+
+Your nodes might need to have `cryptsetup` installed to mount the volumes with LUKS.
 
 ## Upgrading
 


### PR DESCRIPTION
the referenced secret name and namespace was wrong.
Also I added a remark for the nodes to have the cryptsetup package installed, as not all nodes have it by default.
I have tested the name change of the secret in my cluster and can confirm that encryption works