### PR TITLE
Add extra checks for volume attachment

### DIFF
--- a/csi/volume.go
+++ b/csi/volume.go
@@ -13,3 +13,15 @@ type Volume struct {
 func (v Volume) SizeBytes() int64 {
 	return int64(v.Size) * 1024 * 1024 * 1024
 }
+
+// IsAttached returns true if the volume is not attached to
+// a server.
+func (v Volume) IsAttached() bool {
+	return v.Server != nil
+}
+
+// IsMounted returns true if the volume has been mounted to a
+// Linux server and has a mount path.
+func (v Volume) IsMounted() bool {
+	return v.LinuxDevice != ""
+}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -182,6 +182,9 @@ func (s *ControllerService) ControllerPublishVolume(ctx context.Context, req *pr
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get volume: %s", err))
 		}
 	}
+	if !volume.IsMounted() || !volume.IsAttached() {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("volume not yet attached: mounted=%t, attached=%t", volume.IsMounted(), volume.IsAttached()))
+	}
 
 	resp := &proto.ControllerPublishVolumeResponse{
 		PublishContext: map[string]string{


### PR DESCRIPTION
Volume publish can succeed even if the volume is not yet attached or mounted to the underlying Linux server.

https://github.com/hetznercloud/csi-driver/issues/278

The `VolumeAttachement` is meant to contain the mount path:
```
  status:
    attached: true
    attachmentMetadata:
      devicePath: /dev/disk/by-id/scsi-0HC_Volume_20867585
```

but sometimes it does not, meaning that the `ControllerPublishVolumeResponse` did not contain it either.

```
  status:
    attached: true
```

It seems that since this request is only issued once, if the mount path isn't set, it won't be set until the `VolumeAttachment` is deleted and `ControllerPublishVolume` is called again.


According to the [API](https://docs.hetzner.cloud/#volumes-get-a-volume), the `server` field of the  `GET /volume/{id}` is nullable, meaning it won't be set if the volume isn't yet attached.

This PR adds a check to see if the volume is actually attached or not.

## Investigation

```
hcloud-csi-driver level=error ts=2022-12-09T06:24:54.932343015Z component=grpc-server msg="handler failed" err="rpc error: code = Internal desc = failed to publish volume: exit status 1\nmke2fs 1.46.4 (18-Aug-2021)\nThe file  does not exist and no size was specified.\n"
```

Looking at the error, we can see there is an extra space after file in `file  does not...`. Additionally, the log line `component=linux-mount-service msg="formatting disk" disk= fstype=ext4` reveals the `disk` variable is empty. It seems the CSI isn't getting the device path.

I had a quick look at the CSI spec, it seems the [`NodePublishVolume()` request](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodepublishvolume) is the thing which is failing. Specifically it looks like the path isn't in the map here https://github.com/hetznercloud/csi-driver/blob/main/driver/node.go#L60.

That `map[string]string` is apparently set by `ControllerPublishVolume()`:

```
message NodePublishVolumeRequest {
  // The ID of the volume to publish. This field is REQUIRED.
  string volume_id = 1;

  // The CO SHALL set this field to the value returned by
  // `ControllerPublishVolume` if the corresponding Controller Plugin
  // has `PUBLISH_UNPUBLISH_VOLUME` controller capability, and SHALL be
  // left unset if the corresponding Controller Plugin does not have
  // this capability. This is an OPTIONAL field.
  map<string, string> publish_context = 2;
```

This leads to https://github.com/hetznercloud/csi-driver/blob/main/driver/controller.go#L176-L190 which in turn calls https://github.com/hetznercloud/csi-driver/blob/6beac22cec3523a338241ead8a9f6f394c15c666/api/volume.go#L83-L101.
