### PR TITLE
fix(node): check for empty devicePath

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -58,6 +58,9 @@ func (s *NodeService) NodePublishVolume(ctx context.Context, req *proto.NodePubl
 	}
 
 	devicePath := req.GetPublishContext()["devicePath"]
+	if devicePath == "" {
+		return nil, status.Error(codes.InvalidArgument, "missing device path")
+	}
 
 	var opts volumes.MountOpts
 	switch {

--- a/driver/node_test.go
+++ b/driver/node_test.go
@@ -135,6 +135,9 @@ func TestNodeServiceNodePublishPublishError(t *testing.T) {
 				},
 			},
 		},
+		PublishContext: map[string]string{
+			"devicePath": "devpath",
+		},
 	})
 	if grpc.Code(err) != codes.Internal {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
When the VolumeAttachment was created with v1.6.0 (or older) it has an empty publish context and we run into a cryptic error during mount. We should always check that the device path is set in the publish context.

This will improve the error message for one of the bugs encountered in #278.

For details, see my comment: https://github.com/hetznercloud/csi-driver/issues/278#issuecomment-1351652816