### PR TITLE
refactor(skaffold): update manifests to match v2+ resources

### DIFF
--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -14,19 +14,24 @@ patches:
         path: /spec/template/spec/containers/1/env/-
         value:
           name: LOG_LEVEL
-          value: info
-#      - op: replace
-#        path: /spec/template/spec/containers/1/env/2/valueFrom/secretKeyRef/name
-#        value: hcloud_token
+          value: debug
+      - op: add
+        path: /spec/template/spec/containers/1/env/-
+        value:
+          name: HCLOUD_DEBUG
+          value: "true"
+          
   - target:
-      kind: StatefulSet
+      kind: Deployment
       name: hcloud-csi-controller
     patch: |-
       - op: add
         path: /spec/template/spec/containers/3/env/-
         value:
           name: LOG_LEVEL
-          value: info
-      - op: replace
-        path: /spec/template/spec/containers/3/env/3/valueFrom/secretKeyRef/name
-        value: hcloud
+          value: debug
+      - op: add
+        path: /spec/template/spec/containers/3/env/-
+        value:
+          name: HCLOUD_DEBUG
+          value: "true"

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -6,32 +6,36 @@ kind: Kustomization
 resources:
   - ../deploy
 patches:
-  - target:
+  - patch: |-
       kind: DaemonSet
-      name: hcloud-csi-node
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/1/env/-
-        value:
-          name: LOG_LEVEL
-          value: debug
-      - op: add
-        path: /spec/template/spec/containers/1/env/-
-        value:
-          name: HCLOUD_DEBUG
-          value: "true"
-          
-  - target:
+      apiVersion: apps/v1
+      metadata:
+        name: hcloud-csi-node
+        namespace: kube-system
+      spec:
+        template:
+          spec:
+            containers:
+            - name: hcloud-csi-driver
+              env:
+              - name: LOG_LEVEL
+                value: info
+              # - name: HCLOUD_DEBUG
+              #   value: "true"
+
+  - patch: |-
       kind: Deployment
-      name: hcloud-csi-controller
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/3/env/-
-        value:
-          name: LOG_LEVEL
-          value: debug
-      - op: add
-        path: /spec/template/spec/containers/3/env/-
-        value:
-          name: HCLOUD_DEBUG
-          value: "true"
+      apiVersion: apps/v1
+      metadata:
+        name: hcloud-csi-controller
+        namespace: kube-system
+      spec:
+        template:
+          spec:
+            containers:
+            - name: hcloud-csi-driver
+              env:
+              - name: LOG_LEVEL
+                value: info
+              # - name: HCLOUD_DEBUG
+              #   value: "true"


### PR DESCRIPTION
In v2 we made multiple changes to our deployment manifests that were not
mirrored in the skaffold patches for local development:

- Remove hcloud token from node
- Use Deployment instead of StatefulSet for controller

This commit updates the skaffold patches to (better) work with the new
version.