### PR TITLE
feat: test against Kubernetes v1.26

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        k8s: [ k8s-1.22.15, k8s-1.23.13, k8s-1.24.7, k8s-1.25.3 ]
+        k8s: [ k8s-1.23.15, k8s-1.24.9, k8s-1.25.5, k8s-1.26.0 ]
     name: k8s ${{ matrix.k8s }}
     steps:
     - uses: actions/setup-go@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ include:
 
 stages:
   - test
-  - E2E
+  - e2e-test
   - build
   - release
 
@@ -22,34 +22,15 @@ unit:
     - hc-bladerunner
 
 
-.k8se2e: &k8se2e
+e2e:
   image: docker:git
-  stage: E2E
-  variables:
-    K8S_VERSION: k8s-1.17.14
+  stage: e2e-test
+  parallel:
+    matrix:
+      - K8S_VERSION: [ k8s-1.23.15, k8s-1.24.9, k8s-1.25.5, k8s-1.26.0 ]
   before_script:
     - apk add --no-cache git make musl-dev go
   script:
     - go test $(go list ./... | grep e2etests) -v -timeout 60m
   tags:
     - hc-bladerunner-build
-
-k8s 1.22:
-  <<: *k8se2e
-  variables:
-    K8S_VERSION: k8s-1.22.15
-
-k8s 1.23:
-  <<: *k8se2e
-  variables:
-    K8S_VERSION: k8s-1.23.13
-
-k8s 1.24:
-  <<: *k8se2e
-  variables:
-    K8S_VERSION: k8s-1.24.7
-
-k8s 1.25:
-  <<: *k8se2e
-  variables:
-    K8S_VERSION: k8s-1.25.3

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ related only to an unsupported version.
 
 | Kubernetes | CSI Driver |                                                                                   Deployment File |
 | ---------- | ---------: | ------------------------------------------------------------------------------------------------: |
+| 1.26       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.25       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.24       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.23       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -25,13 +25,19 @@ func TestMain(m *testing.M) {
 
 func TestOfficialTestsuite(t *testing.T) {
 	t.Run("parallel tests", func(t *testing.T) {
-		err := RunCommandVisibleOnServer(testCluster.setup.privKey, testCluster.setup.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config ./ginkgo -nodes=6 -v -focus='External.Storage' -skip='\\[Feature:|\\[Disruptive\\]|\\[Serial\\]' ./e2e.test -- -storage.testdriver=test-driver.yml"))
+		err := RunCommandVisibleOnServer(testCluster.setup.privKey, testCluster.setup.MainNode, "KUBECONFIG=/root/.kube/config ./ginkgo -nodes=6 -v -focus='External.Storage' -skip='\\[Feature:|\\[Disruptive\\]|\\[Serial\\]' ./e2e.test -- -storage.testdriver=test-driver.yml")
 		if err != nil {
 			t.Error(err)
 		}
 	})
 	t.Run("serial tests", func(t *testing.T) {
-		err := RunCommandVisibleOnServer(testCluster.setup.privKey, testCluster.setup.MainNode, fmt.Sprintf("KUBECONFIG=/root/.kube/config ./ginkgo -v -focus='External.Storage.*(\\[Feature:|\\[Serial\\])' ./e2e.test -- -storage.testdriver=test-driver.yml"))
+		// Tests tagged as "Feature:SELinuxMountReadWriteOncePod" were added in
+		// Kubernetes v1.26, and fail for us because we do not support the
+		// SINGLE_NODE_MULTI_WRITER Capability (equivalent to ReadWriteOncePod
+		// Volume Access Mode in Kubernetes).
+		// This feature is being tracked in https://github.com/hetznercloud/csi-driver/issues/327
+		// and we should add the tests once we have implemented the capability.
+		err := RunCommandVisibleOnServer(testCluster.setup.privKey, testCluster.setup.MainNode, "KUBECONFIG=/root/.kube/config ./ginkgo -v -focus='External.Storage.*(\\[Feature:|\\[Serial\\])' -skip='\\[Feature:SELinuxMountReadWriteOncePod\\]' ./e2e.test -- -storage.testdriver=test-driver.yml")
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Add support for v1.26 and drop support for v1.22, in accordance with our Kubernetes version support policy (last 3 releases, same as upstream).