### PR TITLE
fix: Block volumes are formatted #349

### DIFF
--- a/integrationtests/docker.go
+++ b/integrationtests/docker.go
@@ -48,7 +48,7 @@ func runCmdWithStdin(stdin string, name string, args ...string) (string, error) 
 	outputBytes, err := cmd.CombinedOutput()
 	output := string(outputBytes)
 	if err != nil {
-		return output, fmt.Errorf("run command %s failed: %w\n%s", strings.Join(append([]string{name}, args...), " "), err, output)
+		return output, fmt.Errorf("run command %s failed: %w\n", strings.Join(append([]string{name}, args...), " "), err)
 	}
 	return output, nil
 }

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -26,7 +26,7 @@ func prepareDockerImage() error {
 	defer os.Unsetenv("GOARCH")
 	os.Setenv("CGO_ENABLED", "0")
 	defer os.Unsetenv("CGO_ENABLED")
-	if output, err := runCmd("go", "test", ".", "-c", "-o", "integrationtests.tests"); err != nil {
+	if output, err := runCmd("go", "test", "-c", "-o", "integrationtests.tests"); err != nil {
 		fmt.Printf("Error compiling test binary: %v\n%s\n", err, output)
 		os.Exit(1)
 	}

--- a/integrationtests/volumes_test.go
+++ b/integrationtests/volumes_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"runtime"
 	"testing"
 
@@ -18,19 +19,20 @@ func TestVolumePublishUnpublish(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		passphrase    string
+		mountOpts     volumes.MountOpts
 		prepare       func(svc volumes.MountService, cs *volumes.CryptSetup, device string) error
 		expectedError error
 	}{
+		// Block volume not formatted
 		{
 			"plain",
-			"",
+			volumes.MountOpts{},
 			nil,
 			nil,
 		},
 		{
 			"plain-correct-formatted",
-			"",
+			volumes.MountOpts{},
 			func(svc volumes.MountService, cs *volumes.CryptSetup, device string) error {
 				return svc.FormatDisk(device, "ext4")
 			},
@@ -38,21 +40,27 @@ func TestVolumePublishUnpublish(t *testing.T) {
 		},
 		{
 			"plain-wrong-formatted",
-			"",
+			volumes.MountOpts{},
 			func(svc volumes.MountService, cs *volumes.CryptSetup, device string) error {
 				return svc.FormatDisk(device, "xfs")
 			},
 			fmt.Errorf("requested ext4 volume, but disk /dev-fake-plain-wrong-formatted already is formatted with xfs"),
 		},
 		{
+			"block-volume",
+			volumes.MountOpts{BlockVolume: true},
+			nil,
+			nil,
+		},
+		{
 			"encrypted",
-			"passphrase",
+			volumes.MountOpts{EncryptionPassphrase: "passphrase"},
 			nil,
 			nil,
 		},
 		{
 			"encrypted-correct-formatted-1",
-			"passphrase",
+			volumes.MountOpts{EncryptionPassphrase: "passphrase"},
 			func(svc volumes.MountService, cs *volumes.CryptSetup, device string) error {
 				if err := cs.Format(device, "passphrase"); err != nil {
 					return err
@@ -63,7 +71,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 		},
 		{
 			"encrypted-correct-formatted-2",
-			"passphrase",
+			volumes.MountOpts{EncryptionPassphrase: "passphrase"},
 			func(svc volumes.MountService, cs *volumes.CryptSetup, device string) error {
 				if err := cs.Format(device, "passphrase"); err != nil {
 					return err
@@ -83,7 +91,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 		},
 		{
 			"encrypted-wrong-formatted-1",
-			"passphrase",
+			volumes.MountOpts{EncryptionPassphrase: "passphrase"},
 			func(svc volumes.MountService, cs *volumes.CryptSetup, device string) error {
 				return svc.FormatDisk(device, "ext4")
 			},
@@ -93,6 +101,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+
 			logger := log.NewLogfmtLogger(NewTestingWriter(t))
 			mountService := volumes.NewLinuxMountService(logger)
 			cryptSetup := volumes.NewCryptSetup(logger)
@@ -107,29 +116,70 @@ func TestVolumePublishUnpublish(t *testing.T) {
 				}
 			}
 
-			targetPath, err := ioutil.TempDir(os.TempDir(), "")
+			targetPath, err := ioutil.TempDir(os.TempDir(), "csi-driver")
 			if err != nil {
 				t.Fatal()
 			}
+			// Make sure that target path is non-existant
+			// Required as FS volumes require target dir, but block volumes require
+			// target file
+			targetPath = path.Join(targetPath, "target-path")
 
-			if err := mountService.Publish(targetPath, device, volumes.MountOpts{
-				EncryptionPassphrase: test.passphrase,
-			}); err != nil {
-				if test.expectedError == nil {
-					t.Fatal(err)
-				} else if test.expectedError.Error() != err.Error() {
-					t.Fatal(fmt.Errorf("expected error %q but got %q", test.expectedError.Error(), err.Error()))
+			publishErr := mountService.Publish(targetPath, device, test.mountOpts)
+			if test.expectedError != nil {
+				// We expected an error
+				if publishErr == nil {
+					t.Fatalf("expected error %q but got no error", test.expectedError.Error())
+				} else if test.expectedError.Error() != publishErr.Error() {
+					t.Fatal(fmt.Errorf("expected error %q but got %q", test.expectedError.Error(), publishErr.Error()))
+				}
+
+				// Makes no sense to continue verification if we got the error that we expected
+				_ = mountService.Unpublish(targetPath)
+				return
+			} else {
+				if err != nil {
+					t.Fatal(publishErr)
 				}
 			}
 			defer mountService.Unpublish(targetPath)
 
-			if _, err := ioutil.ReadDir(targetPath); err != nil {
+			// Verify target exists and is of expected type
+			fileInfo, err := os.Stat(targetPath)
+			if err != nil {
 				t.Fatal(err)
+			}
+			isDir := fileInfo.IsDir()
+
+			if test.mountOpts.BlockVolume && isDir {
+				t.Fatal("targetPath expected to be a file for block volumes, but is a directory")
 			}
 
-			if err := mountService.Unpublish(targetPath); err != nil {
-				t.Fatal(err)
+			if !test.mountOpts.BlockVolume && !isDir {
+				t.Fatal("targetPath expected to be a directory for fs volumes, but is a file")
 			}
+
+			if test.mountOpts.EncryptionPassphrase == "" {
+				// Verify device has expected fs type
+				// Encrypted volumes always have "crypto_LUKS"
+				fsType, err := mountService.DetectDiskFormat(device)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedFSType := test.mountOpts.FSType
+				if expectedFSType == "" && !test.mountOpts.BlockVolume {
+					// ext4 is default fs type
+					expectedFSType = "ext4"
+				}
+				if fsType != expectedFSType {
+					t.Fatalf("expected device to have fs type '%s', but device is formatted with '%s'", expectedFSType, fsType)
+				}
+
+				if err := mountService.Unpublish(targetPath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
A recently introduced change (#279) caused block volumes to be formatted with ext4. This happened because setting the default for the FS type was moved from the non-Block Volume branch into the general code.

This PR reverts the move and adds a test to make sure that block storage is not accidentally formatted again in the future.