### PR TITLE
Update k8s sig-storage containers

### DIFF
--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -209,12 +209,14 @@ spec:
         app: hcloud-csi-controller
     spec:
       containers:
-      - image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+      - args:
+        - --default-fstype=ext4
+        image: k8s.gcr.io/sig-storage/csi-attacher:v4.1.0
         name: csi-attacher
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+      - image: k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /run/csi
@@ -222,7 +224,7 @@ spec:
       - args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+        image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0
         name: csi-provisioner
         volumeMounts:
         - mountPath: /run/csi
@@ -266,7 +268,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -305,7 +307,7 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
         name: csi-node-driver-registrar
         volumeMounts:
         - mountPath: /run/csi
@@ -348,7 +350,7 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -385,7 +387,7 @@ metadata:
   name: csi.hetzner.cloud
 spec:
   attachRequired: true
+  fsGroupPolicy: File
   podInfoOnMount: true
   volumeLifecycleModes:
   - Persistent
-  fsGroupPolicy: File


### PR DESCRIPTION
Updated the full manifest by running: `kustomize build deploy/kubernetes > deploy/kubernetes/hcloud-csi.yml`

All new containers support kubernetes from 1.20 onwards.

https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.7.0
https://github.com/kubernetes-csi/external-attacher/releases/tag/v4.1.0
https://github.com/kubernetes-csi/external-provisioner/releases/tag/v3.4.0
https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v2.7.0
https://github.com/kubernetes-csi/livenessprobe/releases/tag/v2.9.0