### PR TITLE
Remove explicit image pull policies

### DIFF
--- a/deploy/kubernetes/controller/deployment.yaml
+++ b/deploy/kubernetes/controller/deployment.yaml
@@ -37,7 +37,6 @@ spec:
           mountPath: /run/csi
       - name: hcloud-csi-driver
         image: hetznercloud/hcloud-csi-driver:latest
-        imagePullPolicy: Always
         command: [/bin/hcloud-csi-driver-controller]
         env:
         - name: CSI_ENDPOINT
@@ -74,7 +73,6 @@ spec:
           timeoutSeconds: 3
           periodSeconds: 2
       - name: liveness-probe
-        imagePullPolicy: Always
         image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
         volumeMounts:
         - mountPath: /run/csi

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -249,7 +249,6 @@ spec:
               key: token
               name: hcloud
         image: hetznercloud/hcloud-csi-driver:latest
-        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -269,7 +268,6 @@ spec:
         - mountPath: /run/csi
           name: socket-dir
       - image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
-        imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
         - mountPath: /run/csi
@@ -324,7 +322,6 @@ spec:
         - name: ENABLE_METRICS
           value: "true"
         image: hetznercloud/hcloud-csi-driver:latest
-        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -351,7 +348,6 @@ spec:
         - mountPath: /dev
           name: device-dir
       - image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
-        imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
         - mountPath: /run/csi

--- a/deploy/kubernetes/node/daemonset.yaml
+++ b/deploy/kubernetes/node/daemonset.yaml
@@ -42,7 +42,6 @@ spec:
           mountPath: /registration
       - name: hcloud-csi-driver
         image: hetznercloud/hcloud-csi-driver:latest
-        imagePullPolicy: Always
         command: [/bin/hcloud-csi-driver-node]
         env:
         - name: CSI_ENDPOINT
@@ -76,7 +75,6 @@ spec:
           timeoutSeconds: 3
           periodSeconds: 2
       - name: liveness-probe
-        imagePullPolicy: Always
         image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
         volumeMounts:
         - mountPath: /run/csi

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -333,7 +333,6 @@ func (s *hcloudK8sSetup) prepareCSIDriverDeploymentFile() error {
 
 	fmt.Printf("[%s] %s: Prepare deployment file and transfer it\n", s.MainNode.Name, op)
 	deploymentFile = []byte(strings.ReplaceAll(string(deploymentFile), "hetznercloud/hcloud-csi-driver:latest", fmt.Sprintf("hcloud-csi:ci_%s", s.TestIdentifier)))
-	deploymentFile = []byte(strings.ReplaceAll(string(deploymentFile), " imagePullPolicy: Always", " imagePullPolicy: IfNotPresent"))
 
 	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("echo '%s' >> csi-driver.yml", deploymentFile))
 	if err != nil {


### PR DESCRIPTION
If image pull policy is not specified, then latest images implicitly have the pull policy Always. All other sig-storage images are versioned and hence have IfNotPresent by default.