### PR TITLE
chore(e2e): update testdriver definition

### DIFF
--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -27,6 +27,7 @@ type K8sDistribution string
 const (
 	K8sDistributionK8s K8sDistribution = "k8s"
 	K8sDistributionK3s K8sDistribution = "k3s"
+	TestDriverFilePath                 = "templates/testdrivers/1.23.yml"
 )
 
 var instanceType = "cpx21"
@@ -253,15 +254,15 @@ func (s *hcloudK8sSetup) PrepareK8s() (string, error) {
 	}
 
 	fmt.Printf("[%s] %s: Read test-driver.yml configuration file\n", s.MainNode.Name, op)
-	testDriverFile, err := ioutil.ReadFile("templates/testdrivers/1.18.yml")
+	testDriverFile, err := ioutil.ReadFile(TestDriverFilePath)
 	if err != nil {
-		return "", fmt.Errorf("%s read testdriverfile file: %s %v", op, "templates/testdrivers/1.18.yml", err)
+		return "", fmt.Errorf("%s read testdriverfile file: %s %v", op, TestDriverFilePath, err)
 	}
 
 	fmt.Printf("[%s] %s: Transfer test-driver.yml configuration file\n", s.MainNode.Name, op)
 	err = RunCommandOnServer(s.privKey, s.MainNode, fmt.Sprintf("echo '%s' >> test-driver.yml", testDriverFile))
 	if err != nil {
-		return "", fmt.Errorf("%s send testdriverfile file: %s %v", op, "templates/testdrivers/1.18.yml", err)
+		return "", fmt.Errorf("%s send testdriverfile file: %s %v", op, TestDriverFilePath, err)
 	}
 	fmt.Printf("[%s] %s: Download kubeconfig\n", s.MainNode.Name, op)
 	err = scp("ssh_key", fmt.Sprintf("root@%s:/root/.kube/config", s.MainNode.PublicNet.IPv4.IP.String()), "kubeconfig")

--- a/e2etests/templates/testdrivers/1.23.yml
+++ b/e2etests/templates/testdrivers/1.23.yml
@@ -6,18 +6,25 @@ DriverInfo:
     Max: 15Gi
     Min: 10Gi
   Capabilities:
+    # Available capabilities are defined in the kubernetes repositories, make
+    # sure to select the corresponding k8s version:
+    # https://github.com/kubernetes/kubernetes/blob/release-1.23/test/e2e/storage/framework/testdriver.go#L150
     persistence: true
     block: true
     fsGroup: true
+    volumeMountGroup: false
     exec: false
     snapshotDataSource: false
     pvcDataSource: false
+    multipods: true
     RWX: false
-    multipods: false
     controllerExpansion: true
     nodeExpansion: true
+    onlineExpansion: false
     volumeLimits: false
     singleNodeVolume: true
+    topology: true
+    capacity: false
   SupportedFsType:
     ext4:
     xfs:


### PR DESCRIPTION
Update our test driver definition to specify all capabilities available in Kubernetes v1.23, the lowest version against which we test.