### PR TITLE
ci: disable CGO in e2e pipeline

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Run tests
       env:
         K8S_VERSION: ${{ matrix.k8s }}
+        CGO_ENABLED: "0"
       run: |
         go test $(go list ./... | grep e2etests) -v -timeout 60m
         ./script/delete-token.sh $HCLOUD_TOKEN


### PR DESCRIPTION
We do not require CGO for our e2e pipeline, but somehow it started being used on 2023-01-13.