### PR TITLE
docs: update README for v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ enabling you to use ReadWriteOnce Volumes within Kubernetes. Please note that th
 
     Have a look at our [Version Matrix](README.md#versioning-policy) to pick the correct deployment file.
    ```
-   kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml
+   kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.1/deploy/kubernetes/hcloud-csi.yml
    ```
 
 4. To verify everything is working, create a persistent volume claim and a pod
@@ -141,7 +141,7 @@ There are two breaking changes between v1.6 and v2.0 that require user intervent
 **Rollout the new manifest**:
 
 ```shell
-$ kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml
+$ kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.1/deploy/kubernetes/hcloud-csi.yml
 ```
 
 **After the rollout**:
@@ -179,10 +179,10 @@ related only to an unsupported version.
 
 | Kubernetes | CSI Driver |                                                                                   Deployment File |
 | ---------- | ---------: | ------------------------------------------------------------------------------------------------: |
-| 1.26       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.25       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.24       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.23       |      2.1.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.0/deploy/kubernetes/hcloud-csi.yml |
+| 1.26       |      2.1.1 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.25       |      2.1.1 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.24       |      2.1.1 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.23       |      2.1.1 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.1.1/deploy/kubernetes/hcloud-csi.yml |
 | 1.22       |      1.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.21       |      1.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.20       |      1.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |


### PR DESCRIPTION
Update docs to point to version [`v2.1.1`](https://github.com/hetznercloud/csi-driver/releases/tag/v2.1.1)