### PR TITLE
feat: set allow discards on luksOpen

### DIFF
--- a/volumes/cryptsetup.go
+++ b/volumes/cryptsetup.go
@@ -55,7 +55,7 @@ func (cs *CryptSetup) Open(devicePath string, luksDeviceName string, passphrase 
 		"devicePath", devicePath,
 		"luksDeviceName", luksDeviceName,
 	)
-	output, _, err := commandWithStdin(passphrase, cryptsetupExecuable, "luksOpen", devicePath, luksDeviceName)
+	output, _, err := commandWithStdin(passphrase, cryptsetupExecuable, "luksOpen", "--allow-discards", devicePath, luksDeviceName)
 	if err != nil {
 		return fmt.Errorf("unable to open LUKS device %s: %s", devicePath, output)
 	}


### PR DESCRIPTION
By default Hetzner Cloud uses thin provisioning for Volumes. This way, only the space that is actually used by the customer needs to be allocated in the storage pools.

Encrypting the volumes using LUKS breaks this thin provisioning, and the full amount needs to be allocated.

By setting allow-discards when mounting the volume, we tell the driver to use TRIM/discard, which re-enables the thin-provisioning for the volume.

This can be done when creating the LUKS partition, or when mounting it. By doing it on the mount, this will also be enabled for volumes that already exist prior to this commit when they are being re-attach anyway.