### PR TITLE
feat(k8s): pull CSI sidecar images from registry.k8s.io #368

### DIFF
--- a/deploy/kubernetes/controller/deployment.yaml
+++ b/deploy/kubernetes/controller/deployment.yaml
@@ -16,19 +16,19 @@ spec:
       serviceAccountName: hcloud-csi-controller
       containers:
       - name: csi-attacher
-        image: k8s.gcr.io/sig-storage/csi-attacher:v4.1.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.1.0
         args:
         - --default-fstype=ext4
         volumeMounts:
         - name: socket-dir
           mountPath: /run/csi
       - name: csi-resizer
-        image: k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
         volumeMounts:
         - name: socket-dir
           mountPath: /run/csi
       - name: csi-provisioner
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
         args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
@@ -75,7 +75,7 @@ spec:
           periodSeconds: 2
       - name: liveness-probe
         imagePullPolicy: Always
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -211,12 +211,12 @@ spec:
       containers:
       - args:
         - --default-fstype=ext4
-        image: k8s.gcr.io/sig-storage/csi-attacher:v4.1.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.1.0
         name: csi-attacher
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /run/csi
@@ -224,7 +224,7 @@ spec:
       - args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
         name: csi-provisioner
         volumeMounts:
         - mountPath: /run/csi
@@ -268,7 +268,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -307,7 +307,7 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
         name: csi-node-driver-registrar
         volumeMounts:
         - mountPath: /run/csi
@@ -350,7 +350,7 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:

--- a/deploy/kubernetes/node/daemonset.yaml
+++ b/deploy/kubernetes/node/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
                 - "true"
       containers:
       - name: csi-node-driver-registrar
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
         args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
         volumeMounts:
@@ -77,7 +77,7 @@ spec:
           periodSeconds: 2
       - name: liveness-probe
         imagePullPolicy: Always
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         volumeMounts:
         - mountPath: /run/csi
           name: plugin-dir


### PR DESCRIPTION
Closes #368 

Pull images from `registry.k8s.io` instead of `k8s.gcr.io`. The new registry supports multiple backends (Google Cloud & AWS so far) and should be preferred. At some point new releases for the sidecars wont be pushed to `k8s.gcr.io` anymore.