### PR TITLE
docs(v2): describe process to prepare VolumeAttachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In case of a new major version, there might be manual steps that you need to fol
 
 ### From v1 to v2
 
-There are two breaking changes between v1.6 and v2.0 that require user intervention. Please take care to follow these steps, as otherwise the update might fail.
+There are three breaking changes between v1.6 and v2.0 that require user intervention. Please take care to follow these steps, as otherwise the update might fail.
 
 **Before the rollout**:
 
@@ -136,6 +136,15 @@ There are two breaking changes between v1.6 and v2.0 that require user intervent
    ```shell
    $ kubectl delete statefulset -n kube-system hcloud-csi-controller
    $ kubectl delete daemonset -n kube-system hcloud-csi-node
+   ```
+
+4. We changed the way the device path of mounted volumes is communicated to the node service. This requires changes to the `VolumeAttachment` objects, where we need to add information to the `status.attachmentMetadata` field. Execute the linked script to automatically add the required information. This requires `kubectl` version `v1.24+`, even if your cluster is running v1.23.
+
+   ```shell
+   $ kubectl version
+   $ curl https://raw.githubusercontent.com/hetznercloud/csi-driver/main/docs/v2-fix-volumeattachments/fix-volumeattachments.sh ./fix-volumeattachments.sh
+   $ chmod +x ./fix-volumeattachments.sh
+   $ ./fix-volumeattachments.sh
    ```
 
 **Rollout the new manifest**:

--- a/docs/v2-fix-volumeattachments/fix-volumeattachments.sh
+++ b/docs/v2-fix-volumeattachments/fix-volumeattachments.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+if [ "$DEBUG" != "" ];
+then
+  set -x
+fi
+
+DIR="./hcloud-csi-fix-volumeattachments"
+echo "[INFO] Creating a new directory to write logs: ${DIR}"
+mkdir --parents "${DIR}"
+
+# Logging utility
+LOG_FILE="${DIR}/logs.txt"
+write_log() {
+  echo "$1"
+  echo "$1" >> "${LOG_FILE}"
+}
+
+# Verify dependencies
+verify_installed() {
+  cmd="$1"
+  if ! command -v "$cmd" &> /dev/null
+  then
+    write_log "[ERR] For the script to run successfully, \"${cmd}\" is required, but it could not be found. Please make sure it is installed."
+    exit
+  fi
+}
+
+verify_installed kubectl
+verify_installed grep
+
+VOLUME_ATTACHMENTS=$(
+  kubectl get volumeattachment \
+    -o custom-columns=NAME:.metadata.name,ATTACHER:.spec.attacher,DEVICEPATH:.status.attachmentMetadata.devicePath \
+  | { grep -E 'csi\.hetzner\.cloud.*<none>' --color=never || true; } \
+  | cut --fields=1 --delimiter=' '
+)
+
+if [[ -z "$VOLUME_ATTACHMENTS" ]]; then
+  write_log "[INFO] No affected VolumeAttachments found, exiting."
+  exit 0
+fi
+
+for VOLUME_ATTACHMENT in "$VOLUME_ATTACHMENTS"; do
+  write_log "[INFO] Processing VolumeAttachment $VOLUME_ATTACHMENT"
+
+
+  PV_NAME=$(
+    kubectl get volumeattachment \
+      -o=jsonpath="{.spec.source.persistentVolumeName}" \
+      "$VOLUME_ATTACHMENT"
+  )
+
+  VOLUME_ID=$(
+    kubectl get persistentvolume \
+      -o=jsonpath="{.spec.csi.volumeHandle}" \
+      "$PV_NAME"
+  )
+
+  write_log "[INFO] VolumeAttachment $VOLUME_ATTACHMENT uses volume $VOLUME_ID"
+
+  DEVICE_PATH="/dev/disk/by-id/scsi-0HC_Volume_${VOLUME_ID}"
+
+  kubectl patch volumeattachment \
+    --subresource=status \
+    --type=strategic \
+    -p "{\"status\":{\"attachmentMetadata\": {\"devicePath\":\"${DEVICE_PATH}\"}}}" \
+    "$VOLUME_ATTACHMENT"
+
+  write_log "[INFO] Patched VolumeAttachment $VOLUME_ATTACHMENT"
+done
+
+write_log "[INFO] Finished processing all VolumeAttachments!"


### PR DESCRIPTION
Provide script to prepare VolumeAttachments before migrating to v2.x.y of the csi-driver.

Closes #372
Related to one of the issues described in https://github.com/hetznercloud/csi-driver/issues/278#issuecomment-1351652816