### PR TITLE
feat: use exponential backoff for action polling

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -137,7 +137,7 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger log.Logger)
 		pollingInterval = tmp
 	}
 
-	opts = append(opts, hcloud.WithPollInterval(time.Duration(pollingInterval)*time.Second))
+	opts = append(opts, hcloud.WithPollBackoffFunc(hcloud.ExponentialBackoff(2, time.Duration(pollingInterval)*time.Second)))
 
 	return hcloud.NewClient(opts...), nil
 }


### PR DESCRIPTION
By using exponential backoff we can reduce the number of API requests made, and better conserve our API rate limit.

Related to #346

Rebased on #379 as hcloud-go 1.40.0 added customizable polling backoff functions.