### PR TITLE
Separate server ID from location for controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -29,12 +29,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	metadataClient := metadata.NewClient(metadata.WithInstrumentation(m.Registry()))
 	var location string
 
-	if s := os.Getenv("HCLOUD_SERVER_OVERRIDE_LOCATION_NAME"); s != "" {
+	if s := os.Getenv("HCLOUD_VOLUME_DEFAULT_LOCATION"); s != "" {
 		location = s
 	} else {
+		metadataClient := metadata.NewClient(metadata.WithInstrumentation(m.Registry()))
+
 		server, err := app.GetServer(logger, hcloudClient, metadataClient)
 		if err != nil {
 			level.Error(logger).Log(


### PR DESCRIPTION
This PR adds support to execute the CSI controller on a node not hosted on the Hetzner Cloud. Additionally it reduces required API calls in this case as the location is already known at execution.

It adds a new environment variable `HCLOUD_VOLUME_DEFAULT_LOCATION` used for the controller service to work properly even without a server ID. It further implements changes requested at #282.

This is useful in a Gardener deployment where the "csi-driver-controller" is not necessarily deployed on a node in the Hetzner Cloud offering but still manages volumes for nodes deployed on the cloud.