### PR TITLE
:sparkles: adding helm chart for csi-driver

### DIFF
--- a/deploy/charts/hcloud-csi/.helmignore
+++ b/deploy/charts/hcloud-csi/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/charts/hcloud-csi/Chart.yaml
+++ b/deploy/charts/hcloud-csi/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: csi-hcloud
+description: Helm Chart for the CSI Driver on Hetzner Cloud
+type: application
+home: https://github.com/syself/charts/tree/main/charts/csi-hcloud
+maintainers:
+  - name: Syself
+    email: info@syself.com
+    url: https://github.com/syself
+version: 1.0.0
+appVersion: 2.1.0

--- a/deploy/charts/hcloud-csi/README.md
+++ b/deploy/charts/hcloud-csi/README.md
@@ -1,0 +1,253 @@
+
+# Hcloud CSI
+
+This deploys a production-ready helm chart for the Hcloud CSI.
+
+## TL;DR
+
+```console
+helm repo add syself https://charts.syself.com
+helm install csi syself/hcloud-csi
+```
+
+## Introduction
+
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `csi`:
+
+```console
+helm install csi syself/hcloud-csi
+```
+
+The command deploys hcloud-csi on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `csi` deployment:
+
+```console
+helm delete csi
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+
+### Common parameters
+
+| Name                | Description                                       | Value |
+| ------------------- | ------------------------------------------------- | ----- |
+| `nameOverride`      | String to partially override common.names.name    | `""`  |
+| `fullnameOverride`  | String to fully override common.names.fullname    | `""`  |
+| `namespaceOverride` | String to fully override common.names.namespace   | `""`  |
+| `commonLabels`      | Labels to add to all deployed objects             | `{}`  |
+| `commonAnnotations` | Annotations to add to all deployed objects        | `{}`  |
+| `extraDeploy`       | Array of extra objects to deploy with the release | `[]`  |
+
+### Controller Parameters
+
+| Name                                            | Description                                                                                                                                                  | Value                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| `controller.image.csiAttacher.registry`         | csi-attacher image registry                                                                                                                                  | `registry.k8s.io`                |
+| `controller.image.csiAttacher.repository`       | csi-attacher image repository                                                                                                                                | `sig-storage/csi-attacher`       |
+| `controller.image.csiAttacher.tag`              | csi-attacher image tag (immutable tags are recommended)                                                                                                      | `v4.1.0`                         |
+| `controller.image.csiAttacher.digest`           | csi-attacher image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)      | `""`                             |
+| `controller.image.csiAttacher.pullPolicy`       | csi-attacher image pull policy                                                                                                                               | `IfNotPresent`                   |
+| `controller.image.csiAttacher.pullSecrets`      | csi-attacher image pull secrets                                                                                                                              | `[]`                             |
+| `controller.image.csiResizer.registry`          | csi-resizer image registry                                                                                                                                   | `registry.k8s.io`                |
+| `controller.image.csiResizer.repository`        | csi-resizer image repository                                                                                                                                 | `sig-storage/csi-resizer`        |
+| `controller.image.csiResizer.tag`               | csi-resizer image tag (immutable tags are recommended)                                                                                                       | `v1.7.0`                         |
+| `controller.image.csiResizer.digest`            | csi-resizer image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)       | `""`                             |
+| `controller.image.csiResizer.pullPolicy`        | csi-resizer image pull policy                                                                                                                                | `IfNotPresent`                   |
+| `controller.image.csiResizer.pullSecrets`       | csi-resizer image pull secrets                                                                                                                               | `[]`                             |
+| `controller.image.csiProvisioner.registry`      | csi-provisioner image registry                                                                                                                               | `registry.k8s.io`                |
+| `controller.image.csiProvisioner.repository`    | csi-provisioner image repository                                                                                                                             | `sig-storage/csi-provisioner`    |
+| `controller.image.csiProvisioner.tag`           | csi-provisioner image tag (immutable tags are recommended)                                                                                                   | `v3.4.0`                         |
+| `controller.image.csiProvisioner.digest`        | csi-provisioner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)   | `""`                             |
+| `controller.image.csiProvisioner.pullPolicy`    | csi-provisioner image pull policy                                                                                                                            | `IfNotPresent`                   |
+| `controller.image.csiProvisioner.pullSecrets`   | csi-provisioner image pull secrets                                                                                                                           | `[]`                             |
+| `controller.image.livenessProbe.registry`       | liveness-probe image registry                                                                                                                                | `registry.k8s.io`                |
+| `controller.image.livenessProbe.repository`     | liveness-probe image repository                                                                                                                              | `sig-storage/livenessprobe`      |
+| `controller.image.livenessProbe.tag`            | liveness-probe image tag (immutable tags are recommended)                                                                                                    | `v2.9.0`                         |
+| `controller.image.livenessProbe.digest`         | liveness-probe image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)    | `""`                             |
+| `controller.image.livenessProbe.pullPolicy`     | liveness-probe image pull policy                                                                                                                             | `IfNotPresent`                   |
+| `controller.image.livenessProbe.pullSecrets`    | liveness-probe image pull secrets                                                                                                                            | `[]`                             |
+| `controller.image.hcloudCSIDriver.registry`     | hcloud-csi-driver image registry                                                                                                                             | `docker.io`                      |
+| `controller.image.hcloudCSIDriver.repository`   | hcloud-csi-driver image repository                                                                                                                           | `hetznercloud/hcloud-csi-driver` |
+| `controller.image.hcloudCSIDriver.tag`          | hcloud-csi-driver image tag (immutable tags are recommended)                                                                                                 | `2.2.0`                          |
+| `controller.image.hcloudCSIDriver.digest`       | hcloud-csi-driver image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                             |
+| `controller.image.hcloudCSIDriver.pullPolicy`   | hcloud-csi-driver image pull policy                                                                                                                          | `IfNotPresent`                   |
+| `controller.image.hcloudCSIDriver.pullSecrets`  | hcloud-csi-driver image pull secrets                                                                                                                         | `[]`                             |
+| `controller.replicaCount`                       | Number of controller replicas to deploy                                                                                                                      | `2`                              |
+| `controller.hcloudToken.value`                  | Specifies the value for the hcloudToken. Creates a secret from that value. If you have already a hcloud token secret leave this empty.                       | `""`                             |
+| `controller.hcloudToken.extistingSecret.name`   | Specifies the name of an existing Secret for the hcloud Token                                                                                                | `hcloud`                         |
+| `controller.hcloudToken.extistingSecret.key`    | Specifies the key of an existing Secret for the hcloud Token                                                                                                 | `token`                          |
+| `controller.hcloudVolumeDefaultLocation`        | Set this to the location of your cluster. If set the controller could run anywhere. If leave empty the controller needs to run on a hcloud node.             | `""`                             |
+| `controller.containerPorts.metrics`             | controller metrics container port                                                                                                                            | `9189`                           |
+| `controller.containerPorts.healthz`             | controller healthz container port                                                                                                                            | `9808`                           |
+| `controller.service.ports.metrics`              | controller service metrics port                                                                                                                              | `9189`                           |
+| `controller.service.annotations`                | Additional custom annotations for controller service                                                                                                         | `{}`                             |
+| `controller.rbac.create`                        | Specifies whether RBAC resources should be created                                                                                                           | `true`                           |
+| `controller.rbac.rules`                         | Custom RBAC rules to set                                                                                                                                     | `[]`                             |
+| `controller.livenessProbe.enabled`              | Enable livenessProbe on controller containers                                                                                                                | `true`                           |
+| `controller.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                                      | `10`                             |
+| `controller.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                                             | `2`                              |
+| `controller.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                                            | `3`                              |
+| `controller.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                                          | `5`                              |
+| `controller.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                                          | `1`                              |
+| `controller.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                                                                          | `{}`                             |
+| `controller.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                                                                         | `{}`                             |
+| `controller.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                                                                           | `{}`                             |
+| `controller.resources.csiAttacher.limits`       | The resources limits for the csiAttacher containers                                                                                                          | `{}`                             |
+| `controller.resources.csiAttacher.requests`     | The requested resources for the csiAttacher containers                                                                                                       | `{}`                             |
+| `controller.resources.csiResizer.limits`        | The resources limits for the csiResizer containers                                                                                                           | `{}`                             |
+| `controller.resources.csiResizer.requests`      | The requested resources for the csiResizer containers                                                                                                        | `{}`                             |
+| `controller.resources.csiProvisioner.limits`    | The resources limits for the csiProvisioner containers                                                                                                       | `{}`                             |
+| `controller.resources.csiProvisioner.requests`  | The requested resources for the csiProvisioner containers                                                                                                    | `{}`                             |
+| `controller.resources.livenessProbe.limits`     | The resources limits for the livenessProbe containers                                                                                                        | `{}`                             |
+| `controller.resources.livenessProbe.requests`   | The requested resources for the livenessProbe containers                                                                                                     | `{}`                             |
+| `controller.resources.hcloudCSIDriver.limits`   | The resources limits for the hcloudCSIDriver containers                                                                                                      | `{}`                             |
+| `controller.resources.hcloudCSIDriver.requests` | The requested resources for the hcloudCSIDriver containers                                                                                                   | `{}`                             |
+| `controller.podSecurityContext.enabled`         | Enabled controller pods' Security Context                                                                                                                    | `true`                           |
+| `controller.podSecurityContext.fsGroup`         | Set controller pod's Security Context fsGroup                                                                                                                | `1001`                           |
+| `controller.podLabels`                          | Extra labels for controller pods                                                                                                                             | `{}`                             |
+| `controller.podAnnotations`                     | Annotations for controller pods                                                                                                                              | `{}`                             |
+| `controller.pdb.create`                         | Enable PodDisruptionBudged for controller pods                                                                                                               | `true`                           |
+| `controller.pdb.minAvailable`                   | Set minAvailable for controller pods                                                                                                                         | `1`                              |
+| `controller.pdb.maxUnavailable`                 | Set maxUnavailable for controller pods                                                                                                                       | `""`                             |
+| `controller.autoscaling.enabled`                | Enable autoscaling for controller                                                                                                                            | `false`                          |
+| `controller.autoscaling.minReplicas`            | Minimum number of controller replicas                                                                                                                        | `""`                             |
+| `controller.autoscaling.maxReplicas`            | Maximum number of controller replicas                                                                                                                        | `""`                             |
+| `controller.autoscaling.targetCPU`              | Target CPU utilization percentage                                                                                                                            | `""`                             |
+| `controller.autoscaling.targetMemory`           | Target Memory utilization percentage                                                                                                                         | `""`                             |
+| `controller.affinity`                           | Affinity for controller pods assignment                                                                                                                      | `{}`                             |
+| `controller.nodeSelector`                       | Node labels for controller pods assignment                                                                                                                   | `{}`                             |
+| `controller.tolerations`                        | Tolerations for controller pods assignment                                                                                                                   | `[]`                             |
+| `controller.updateStrategy.type`                | controller statefulset strategy type                                                                                                                         | `RollingUpdate`                  |
+| `controller.priorityClassName`                  | controller pods' priorityClassName                                                                                                                           | `""`                             |
+| `controller.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                                     | `[]`                             |
+| `controller.schedulerName`                      | Name of the k8s scheduler (other than default) for controller pods                                                                                           | `""`                             |
+| `controller.terminationGracePeriodSeconds`      | Seconds Redmine pod needs to terminate gracefully                                                                                                            | `""`                             |
+| `controller.lifecycleHooks`                     | for the controller container(s) to automate configuration before or after startup                                                                            | `{}`                             |
+| `controller.extraEnvVars`                       | Array with extra environment variables to add to controller nodes                                                                                            | `[]`                             |
+| `controller.extraVolumes`                       | Extra Volumes for controller pods                                                                                                                            | `[]`                             |
+| `controller.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the controller container(s)                                                                     | `[]`                             |
+| `controller.sidecars`                           | Add additional sidecar containers to the controller pod(s)                                                                                                   | `[]`                             |
+| `controller.initContainers`                     | Add additional init containers to the controller pod(s)                                                                                                      | `[]`                             |
+
+### Node Parameters
+
+| Name                                             | Description                                                                                                                                                          | Value                                   |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `node.image.CSINodeDriverRegistrar.registry`     | csi-node-driver-registrar image registry                                                                                                                             | `registry.k8s.io`                       |
+| `node.image.CSINodeDriverRegistrar.repository`   | csi-node-driver-registrar image repository                                                                                                                           | `sig-storage/csi-node-driver-registrar` |
+| `node.image.CSINodeDriverRegistrar.tag`          | csi-node-driver-registrar image tag (immutable tags are recommended)                                                                                                 | `v2.7.0`                                |
+| `node.image.CSINodeDriverRegistrar.digest`       | csi-node-driver-registrar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                                    |
+| `node.image.CSINodeDriverRegistrar.pullPolicy`   | csi-node-driver-registrar image pull policy                                                                                                                          | `IfNotPresent`                          |
+| `node.image.CSINodeDriverRegistrar.pullSecrets`  | csi-node-driver-registrar image pull secrets                                                                                                                         | `[]`                                    |
+| `node.image.livenessProbe.registry`              | liveness-probe image registry                                                                                                                                        | `registry.k8s.io`                       |
+| `node.image.livenessProbe.repository`            | liveness-probe image repository                                                                                                                                      | `sig-storage/livenessprobe`             |
+| `node.image.livenessProbe.tag`                   | liveness-probe image tag (immutable tags are recommended)                                                                                                            | `v2.9.0`                                |
+| `node.image.livenessProbe.digest`                | liveness-probe image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)            | `""`                                    |
+| `node.image.livenessProbe.pullPolicy`            | liveness-probe image pull policy                                                                                                                                     | `IfNotPresent`                          |
+| `node.image.livenessProbe.pullSecrets`           | liveness-probe image pull secrets                                                                                                                                    | `[]`                                    |
+| `node.image.hcloudCSIDriver.registry`            | hcloud-csi-driver image registry                                                                                                                                     | `docker.io`                             |
+| `node.image.hcloudCSIDriver.repository`          | hcloud-csi-driver image repository                                                                                                                                   | `hetznercloud/hcloud-csi-driver`        |
+| `node.image.hcloudCSIDriver.tag`                 | hcloud-csi-driver image tag (immutable tags are recommended)                                                                                                         | `2.2.0`                                 |
+| `node.image.hcloudCSIDriver.digest`              | hcloud-csi-driver image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)         | `""`                                    |
+| `node.image.hcloudCSIDriver.pullPolicy`          | hcloud-csi-driver image pull policy                                                                                                                                  | `IfNotPresent`                          |
+| `node.image.hcloudCSIDriver.pullSecrets`         | hcloud-csi-driver image pull secrets                                                                                                                                 | `[]`                                    |
+| `node.containerPorts.metrics`                    | node Metrics container port                                                                                                                                          | `9189`                                  |
+| `node.containerPorts.healthz`                    | node Health container port                                                                                                                                           | `9808`                                  |
+| `node.service.ports.metrics`                     | node service Metrics port                                                                                                                                            | `9189`                                  |
+| `node.service.annotations`                       | Additional custom annotations for node service                                                                                                                       | `{}`                                    |
+| `node.livenessProbe.enabled`                     | Enable livenessProbe on node containers                                                                                                                              | `true`                                  |
+| `node.livenessProbe.initialDelaySeconds`         | Initial delay seconds for livenessProbe                                                                                                                              | `10`                                    |
+| `node.livenessProbe.periodSeconds`               | Period seconds for livenessProbe                                                                                                                                     | `2`                                     |
+| `node.livenessProbe.timeoutSeconds`              | Timeout seconds for livenessProbe                                                                                                                                    | `3`                                     |
+| `node.livenessProbe.failureThreshold`            | Failure threshold for livenessProbe                                                                                                                                  | `5`                                     |
+| `node.livenessProbe.successThreshold`            | Success threshold for livenessProbe                                                                                                                                  | `1`                                     |
+| `node.customLivenessProbe`                       | Custom livenessProbe that overrides the default one                                                                                                                  | `{}`                                    |
+| `node.customReadinessProbe`                      | Custom readinessProbe that overrides the default one                                                                                                                 | `{}`                                    |
+| `node.customStartupProbe`                        | Custom startupProbe that overrides the default one                                                                                                                   | `{}`                                    |
+| `node.resources.CSINodeDriverRegistrar.limits`   | The resources limits for the CSINodeDriverRegistrar containers                                                                                                       | `{}`                                    |
+| `node.resources.CSINodeDriverRegistrar.requests` | The requested resources for the CSINodeDriverRegistrar containers                                                                                                    | `{}`                                    |
+| `node.resources.livenessProbe.limits`            | The resources limits for the livenessProbe containers                                                                                                                | `{}`                                    |
+| `node.resources.livenessProbe.requests`          | The requested resources for the livenessProbe containers                                                                                                             | `{}`                                    |
+| `node.resources.hcloudCSIDriver.limits`          | The resources limits for the hcloudCSIDriver containers                                                                                                              | `{}`                                    |
+| `node.resources.hcloudCSIDriver.requests`        | The requested resources for the hcloudCSIDriver containers                                                                                                           | `{}`                                    |
+| `node.podSecurityContext.enabled`                | Enabled node pods' Security Context                                                                                                                                  | `true`                                  |
+| `node.podSecurityContext.fsGroup`                | Set node pod's Security Context fsGroup                                                                                                                              | `1001`                                  |
+| `node.hostNetwork`                               | Enables the hostNetwork                                                                                                                                              | `false`                                 |
+| `node.podLabels`                                 | Extra labels for node pods                                                                                                                                           | `{}`                                    |
+| `node.podAnnotations`                            | Annotations for node pods                                                                                                                                            | `{}`                                    |
+| `node.affinity`                                  | Affinity for node pods assignment                                                                                                                                    | `{}`                                    |
+| `node.nodeSelector`                              | Node labels for node pods assignment                                                                                                                                 | `{}`                                    |
+| `node.tolerations`                               | Tolerations for node pods assignment                                                                                                                                 | `{}`                                    |
+| `node.updateStrategy.type`                       | node statefulset strategy type                                                                                                                                       | `RollingUpdate`                         |
+| `node.priorityClassName`                         | node pods' priorityClassName                                                                                                                                         | `""`                                    |
+| `node.schedulerName`                             | Name of the k8s scheduler (other than default) for node pods                                                                                                         | `""`                                    |
+| `node.terminationGracePeriodSeconds`             | Seconds Redmine pod needs to terminate gracefully                                                                                                                    | `""`                                    |
+| `node.lifecycleHooks`                            | for the node container(s) to automate configuration before or after startup                                                                                          | `{}`                                    |
+| `node.extraVolumes`                              | Extra Volumes for controller pods                                                                                                                                    | `[]`                                    |
+| `node.extraVolumeMounts`                         | Optionally specify extra list of additional volumeMounts for the node container(s)                                                                                   | `[]`                                    |
+| `node.sidecars`                                  | Add additional sidecar containers to the node pod(s)                                                                                                                 | `[]`                                    |
+| `node.initContainers`                            | Add additional init containers to the node pod(s)                                                                                                                    | `[]`                                    |
+
+### Other Parameters
+
+| Name                                          | Description                                                                                            | Value   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                   | `true`  |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                 | `""`    |
+| `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template)                                       | `{}`    |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                         | `true`  |
+| `metrics.enabled`                             | Enable the export of Prometheus metrics                                                                | `false` |
+| `metrics.serviceMonitor.enabled`              | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false` |
+| `metrics.serviceMonitor.namespace`            | Namespace in which Prometheus is running                                                               | `""`    |
+| `metrics.serviceMonitor.annotations`          | Additional custom annotations for the ServiceMonitor                                                   | `{}`    |
+| `metrics.serviceMonitor.labels`               | Extra labels for the ServiceMonitor                                                                    | `{}`    |
+| `metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in Prometheus                       | `""`    |
+| `metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels                               | `false` |
+| `metrics.serviceMonitor.interval`             | Interval at which metrics should be scraped.                                                           | `""`    |
+| `metrics.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended                                                                | `""`    |
+| `metrics.serviceMonitor.metricRelabelings`    | Specify additional relabeling of metrics                                                               | `[]`    |
+| `metrics.serviceMonitor.relabelings`          | Specify general relabeling                                                                             | `[]`    |
+| `metrics.serviceMonitor.selector`             | Prometheus instance selector labels                                                                    | `{}`    |
+| `storageClasses`                              | Creates one or more storageClasses                                                                     | `{}`    |
+
+
+
+## Additional environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+controller:
+  extraEnvVars:
+    - name: LOG_LEVEL
+      value: debug
+```
+
+## Pod affinity
+
+This chart allows you to set your custom affinity using the `affinity` parameter. Find more information about Pod affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+

--- a/deploy/charts/hcloud-csi/example-prod.values.yaml
+++ b/deploy/charts/hcloud-csi/example-prod.values.yaml
@@ -1,0 +1,97 @@
+fullnameOverride: "csi"
+
+storageClasses:
+- name: standard
+  defaultStorageClass: true
+  reclaimPolicy: Retain
+  allowVolumeExpansion: true
+
+controller:
+  hcloudVolumeDefaultLocation: nbg1
+  priorityClassName: "system-cluster-critical"
+  resources:
+    csiAttacher:
+      limits:
+        memory: 80Mi
+        cpu: 50m
+      requests: 
+        memory: 20Mi
+        cpu: 10m
+    csiResizer:
+      limits:
+        memory: 80Mi
+        cpu: 50m
+      requests: 
+        memory: 20Mi
+        cpu: 10m
+    csiProvisioner:
+      limits:
+        memory: 80Mi
+        cpu: 50m
+      requests: 
+        memory: 20Mi
+        cpu: 10m
+    livenessProbe:
+      limits:
+        memory: 80Mi
+        cpu: 50m
+      requests: 
+        memory: 20Mi
+        cpu: 10m
+    hcloudCSIDriver:
+      limits:
+        memory: 80Mi
+        cpu: 100m
+      requests: 
+        memory: 40Mi
+        cpu: 10m
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: csi-hcloud
+            operator: In
+            values:
+            - controller
+        topologyKey: "kubernetes.io/hostname"
+
+node:
+  priorityClassName: "system-node-critical"
+  resources:
+    CSINodeDriverRegistrar:
+      limits: 
+        memory: 40Mi
+        cpu: 50m
+      requests: 
+        memory: 20Mi
+        cpu: 10m
+    livenessProbe:
+      limits: 
+        memory: 40Mi
+        cpu: 50m
+      requests: 
+        memory: 20Mi
+        cpu: 10m
+    hcloudCSIDriver:
+      limits:
+        memory: 80Mi
+        cpu: 100m
+      requests: 
+        memory: 40Mi
+        cpu: 10m
+  hostNetwork: true
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: NotIn
+            values:
+            - ""
+          - key: "instance.hetzner.cloud/is-root-server"
+            operator: NotIn
+            values:
+            - "true"
+

--- a/deploy/charts/hcloud-csi/templates/NOTES.txt
+++ b/deploy/charts/hcloud-csi/templates/NOTES.txt
@@ -1,0 +1,13 @@
+CHART NAME: {{ .Chart.Name  }}
+CHART VERSION: {{ .Chart.Version  }}
+APP VERSION: {{ .Chart.AppVersion  }}
+
+** Please be patient while the chart is being deployed **
+
+Get the list of pods by executing:
+
+  kubectl get pods --namespace {{ include "common.names.namespace" . | quote }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Access the pod you want to debug by executing
+
+  kubectl exec --namespace {{ include "common.names.namespace" . | quote }} -ti <NAME OF THE POD> -- bash

--- a/deploy/charts/hcloud-csi/templates/_common_images.tpl
+++ b/deploy/charts/hcloud-csi/templates/_common_images.tpl
@@ -1,0 +1,80 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the proper image name
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global ) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if .imageRoot.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+{{- end -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead)
+{{ include "common.images.pullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global) }}
+*/}}
+{{- define "common.images.pullSecrets" -}}
+  {{- $pullSecrets := list }}
+
+  {{- if .global }}
+    {{- range .global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ include "common.images.renderPullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $) }}
+*/}}
+{{- define "common.images.renderPullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- if $context.Values.global }}
+    {{- range $context.Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/deploy/charts/hcloud-csi/templates/_common_labels.tpl
+++ b/deploy/charts/hcloud-csi/templates/_common_labels.tpl
@@ -1,0 +1,18 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Kubernetes standard labels
+*/}}
+{{- define "common.labels.standard" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+helm.sh/chart: {{ include "common.names.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "common.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/deploy/charts/hcloud-csi/templates/_common_name.tpl
+++ b/deploy/charts/hcloud-csi/templates/_common_name.tpl
@@ -1,0 +1,77 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dependency name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+Usage:
+{{ include "common.names.dependency.fullname" (dict "chartName" "dependency-chart-name" "chartValues" .Values.dependency-chart "context" $) }}
+*/}}
+{{- define "common.names.dependency.fullname" -}}
+{{- if .chartValues.fullnameOverride -}}
+{{- .chartValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .chartName .chartValues.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- .context.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .context.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "common.names.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name adding the installation's namespace.
+*/}}
+{{- define "common.names.fullname.namespace" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) (include "common.names.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "common.names.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/hcloud-csi/templates/_common_tplvalues.tpl
+++ b/deploy/charts/hcloud-csi/templates/_common_tplvalues.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/deploy/charts/hcloud-csi/templates/controller/clusterrole.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/clusterrole.yaml
@@ -1,0 +1,67 @@
+{{ if .Values.controller.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "common.names.fullname" . }}-controller
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+# attacher
+- apiGroups: [""]
+  resources: [persistentvolumes]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [""]
+  resources: [nodes]
+  verbs: [get, list, watch]
+- apiGroups: [csi.storage.k8s.io]
+  resources: [csinodeinfos]
+  verbs: [get, list, watch]
+- apiGroups: [storage.k8s.io]
+  resources: [csinodes]
+  verbs: [get, list, watch]
+- apiGroups: [storage.k8s.io]
+  resources: [volumeattachments]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [storage.k8s.io]
+  resources: [volumeattachments/status]
+  verbs: [patch]
+# provisioner
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: [get, list]
+- apiGroups: [""]
+  resources: [persistentvolumes]
+  verbs: [get, list, watch, create, delete, patch]
+- apiGroups: [""]
+  resources: [persistentvolumeclaims, persistentvolumeclaims/status]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [storage.k8s.io]
+  resources: [storageclasses]
+  verbs: [get, list, watch]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [list, watch, create, update, patch]
+- apiGroups: [snapshot.storage.k8s.io]
+  resources: [volumesnapshots]
+  verbs: [get, list]
+- apiGroups: [snapshot.storage.k8s.io]
+  resources: [volumesnapshotcontents]
+  verbs: [get, list]
+# resizer
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+# node
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch, create, update, patch]
+  {{- if .Values.controller.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.controller.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/clusterrolebinding.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "common.names.fullname" . }}-controller
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "common.names.fullname" . }}-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "common.names.serviceAccountName" . }}-controller
+    namespace: {{ include "common.names.namespace" . | quote }}

--- a/deploy/charts/hcloud-csi/templates/controller/deployment.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/deployment.yaml
@@ -1,0 +1,190 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}-controller
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.controller.autoscaling.enabled }}
+  replicas: {{ .Values.controller.replicaCount }}
+  {{- end }}
+  {{- if .Values.controller.updateStrategy }}
+  strategy: {{- toYaml .Values.controller.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  template:
+    metadata:
+      {{- if .Values.controller.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: controller
+        {{- if .Values.controller.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.controller.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "common.names.serviceAccountName" . }}-controller
+      {{- include "common.images.pullSecrets" (dict "images" (list .Values.controller.image) "global" .Values.global) | nindent 6 }}
+      {{- if .Values.controller.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.controller.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.controller.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.controller.schedulerName }}
+      schedulerName: {{ .Values.controller.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.controller.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.controller.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.controller.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.controller.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: csi-attacher
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image.csiAttacher "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.controller.image.csiAttacher.pullPolicy }}
+          {{- if .Values.controller.resources.csiAttacher }}
+          resources: {{- toYaml .Values.controller.resources.csiAttacher | nindent 12 }}
+          {{- end }}
+          args:
+          - --default-fstype=ext4
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /run/csi
+        - name: csi-resizer
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image.csiResizer "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.controller.image.csiResizer.pullPolicy }}
+          {{- if .Values.controller.resources.csiResizer }}
+          resources: {{- toYaml .Values.controller.resources.csiResizer | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /run/csi
+        - name: csi-provisioner
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image.csiProvisioner "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.controller.image.csiProvisioner.pullPolicy }}
+          {{- if .Values.controller.resources.csiProvisioner }}
+          resources: {{- toYaml .Values.controller.resources.csiProvisioner | nindent 12 }}
+          {{- end }}
+          args:
+          - --feature-gates=Topology=true
+          - --default-fstype=ext4
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /run/csi
+        - name: liveness-probe
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image.livenessProbe "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.controller.image.livenessProbe.pullPolicy }}
+          {{- if .Values.controller.resources.livenessProbe }}
+          resources: {{- toYaml .Values.controller.resources.livenessProbe | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - mountPath: /run/csi
+            name: socket-dir
+        - name: hcloud-csi-driver
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image.hcloudCSIDriver "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.controller.image.hcloudCSIDriver.pullPolicy }}
+          command: [/bin/hcloud-csi-driver-controller]
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /run/csi
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///run/csi/socket
+            {{- if .Values.controller.hcloudVolumeDefaultLocation }}
+            - name: HCLOUD_VOLUME_DEFAULT_LOCATION
+              value: {{ .Values.controller.hcloudVolumeDefaultLocation | quote }}
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: METRICS_ENDPOINT
+              value: 0.0.0.0:{{ .Values.controller.containerPorts.metrics }}
+            {{- end }}
+            - name: ENABLE_METRICS
+              value: {{if .Values.metrics.enabled}}"true"{{ else }}"false"{{end}}
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.controller.hcloudToken.value }}
+                  name: {{ template "common.names.fullname" . }}-hcloud-token
+                  key: token
+                  {{- else }}
+                  name: {{ .Values.controller.hcloudToken.extistingSecret.name }}
+                  key: {{ .Values.controller.hcloudToken.extistingSecret.key }}
+                  {{- end }}
+            {{- if .Values.controller.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if .Values.controller.resources.hcloudCSIDriver }}
+          resources: {{- toYaml .Values.controller.resources.hcloudCSIDriver | nindent 12 }}
+          {{- end }}
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.controller.containerPorts.metrics }}
+            {{- end }}
+            - name: healthz
+              protocol: TCP
+              containerPort: {{ .Values.controller.containerPorts.healthz }}
+          {{- if .Values.controller.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.controller.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.controller.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /healthz
+              port: healthz
+          {{- end }}
+          {{- if .Values.controller.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.controller.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.controller.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.controller.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /run/csi
+          {{- if .Values.controller.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.controller.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.controller.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        {{- if .Values.controller.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/hpa.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/hpa.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}-controller
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}-controller
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.controller.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetMemory }}
+    {{- end }}
+    {{- if .Values.controller.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetCPU }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/pdb.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/pdb.yaml
@@ -1,0 +1,26 @@
+{{- $replicaCount := int .Values.controller.replicaCount }}
+{{- if and .Values.controller.pdb.create (or (gt $replicaCount 1) .Values.controller.autoscaling.enabled) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}-controller
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.controller.pdb.minAvailable }}
+  minAvailable: {{ .Values.controller.pdb.minAvailable }}
+  {{- end  }}
+  {{- if .Values.controller.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.controller.pdb.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/secret.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.controller.hcloudToken.value }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-hcloud-token
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  token: {{ .Values.controller.hcloudToken.value | b64enc }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/service.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}-controller-metrics
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.controller.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.controller.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.controller.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  ports:
+    - name: metrics
+      port: {{ .Values.controller.service.ports.metrics }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/serviceaccount.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/serviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "common.names.serviceAccountName" . }}-controller
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+#automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/controller/servicemonitor.yaml
+++ b/deploy/charts/hcloud-csi/templates/controller/servicemonitor.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-controller
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      {{- if .Values.metrics.serviceMonitor.selector }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- end }}
+  endpoints:
+    - port: metrics
+      scheme: "http"
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ include "common.names.namespace" . | quote }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/core/csidriver.yaml
+++ b/deploy/charts/hcloud-csi/templates/core/csidriver.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.hetzner.cloud
+spec:
+  attachRequired: true
+  fsGroupPolicy: File
+  podInfoOnMount: true
+  volumeLifecycleModes:
+  - Persistent

--- a/deploy/charts/hcloud-csi/templates/core/storageclass.yaml
+++ b/deploy/charts/hcloud-csi/templates/core/storageclass.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.storageClasses }}
+{{- range $key, $val := .Values.storageClasses }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ $val.name }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: {{ $val.defaultStorageClass | default "false" | quote }}
+provisioner: csi.hetzner.cloud
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: {{ $val.reclaimPolicy | quote }}
+---
+{{- end }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/extra-list.yaml
+++ b/deploy/charts/hcloud-csi/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/node/daemonset.yaml
+++ b/deploy/charts/hcloud-csi/templates/node/daemonset.yaml
@@ -1,0 +1,162 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "common.names.fullname" . }}-node
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: node
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.node.updateStrategy }}
+  updateStrategy: {{- toYaml .Values.node.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: node
+  template:
+    metadata:
+      {{- if .Values.node.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.node.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: node
+        {{- if .Values.node.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.node.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "common.images.pullSecrets" (dict "images" (list .Values.node.image ) "global" .Values.global) | nindent 6 }}
+      {{- if .Values.node.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.node.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.node.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.node.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.node.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.node.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.node.tolerations "context" .) | nindent 8 }}
+      {{- else }}
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      {{- end }}
+      {{- if .Values.node.priorityClassName }}
+      priorityClassName: {{ .Values.node.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.node.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.node.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.node.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriodSeconds }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.node.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.node.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: csi-node-driver-registrar
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.node.image.CSINodeDriverRegistrar "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.node.image.CSINodeDriverRegistrar.pullPolicy }}
+          args:
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /run/csi
+            - name: registration-dir
+              mountPath: /registration
+          {{- if .Values.node.resources.CSINodeDriverRegistrar }}
+          resources: {{- toYaml .Values.node.resources.CSINodeDriverRegistrar | nindent 12 }}
+          {{- end }}
+        - name: liveness-probe
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.node.image.livenessProbe "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.node.image.livenessProbe.pullPolicy }}
+          volumeMounts:
+          - mountPath: /run/csi
+            name: plugin-dir
+          {{- if .Values.node.resources.livenessProbe }}
+          resources: {{- toYaml .Values.node.resources.livenessProbe | nindent 12 }}
+          {{- end }}
+        - name: hcloud-csi-driver
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.node.image.hcloudCSIDriver "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.node.image.pullPolicy }}
+          command: [/bin/hcloud-csi-driver-node]
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /run/csi
+            - name: device-dir
+              mountPath: /dev
+          securityContext:
+            privileged: true
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///run/csi/socket
+            {{- if .Values.metrics.enabled }}
+            - name: METRICS_ENDPOINT
+              value: 0.0.0.0:{{ .Values.node.containerPorts.metrics }}
+            {{- end }}
+            - name: ENABLE_METRICS
+              value: {{if .Values.metrics.enabled}}"true"{{ else }}"false"{{end}}
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.node.containerPorts.metrics }}
+              name: metrics
+            {{- end }}
+            - name: healthz
+              protocol: TCP
+              containerPort: {{ .Values.node.containerPorts.healthz }}
+          {{- if .Values.node.resources.hcloudCSIDriver }}
+          resources: {{- toYaml .Values.node.resources.hcloudCSIDriver | nindent 12 }}
+          {{- end }}
+          {{- if .Values.node.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.node.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.node.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.node.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /healthz
+              port: healthz
+          {{- end }}
+          {{- if .Values.node.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.node.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.node.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.node.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.node.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.node.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        {{- if .Values.node.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.node.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/deploy/charts/hcloud-csi/templates/node/service.yaml
+++ b/deploy/charts/hcloud-csi/templates/node/service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}-node-metrics
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: node
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.node.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.node.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.node.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  ports:
+    - name: metrics
+      port: {{ .Values.node.service.ports.metrics }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: node
+{{- end }}

--- a/deploy/charts/hcloud-csi/templates/node/servicemonitor.yaml
+++ b/deploy/charts/hcloud-csi/templates/node/servicemonitor.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-node
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      {{- if .Values.metrics.serviceMonitor.selector }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- end }}
+  endpoints:
+    - port: metrics
+      scheme: "http"
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ include "common.names.namespace" . | quote }}
+{{- end }}

--- a/deploy/charts/hcloud-csi/values.yaml
+++ b/deploy/charts/hcloud-csi/values.yaml
@@ -1,0 +1,754 @@
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+
+## @section Common parameters
+##
+
+## @param nameOverride String to partially override common.names.name
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## @section Controller Parameters
+##
+
+## Controller
+##
+controller:
+  ## @param controller.image.csiAttacher.registry csi-attacher image registry
+  ## @param controller.image.csiAttacher.repository csi-attacher image repository
+  ## @param controller.image.csiAttacher.tag csi-attacher image tag (immutable tags are recommended)
+  ## @param controller.image.csiAttacher.digest csi-attacher image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param controller.image.csiAttacher.pullPolicy csi-attacher image pull policy
+  ## @param controller.image.csiAttacher.pullSecrets csi-attacher image pull secrets
+  ## @param controller.image.csiResizer.registry csi-resizer image registry
+  ## @param controller.image.csiResizer.repository csi-resizer image repository
+  ## @param controller.image.csiResizer.tag csi-resizer image tag (immutable tags are recommended)
+  ## @param controller.image.csiResizer.digest csi-resizer image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param controller.image.csiResizer.pullPolicy csi-resizer image pull policy
+  ## @param controller.image.csiResizer.pullSecrets csi-resizer image pull secrets
+  ## @param controller.image.csiProvisioner.registry csi-provisioner image registry
+  ## @param controller.image.csiProvisioner.repository csi-provisioner image repository
+  ## @param controller.image.csiProvisioner.tag csi-provisioner image tag (immutable tags are recommended)
+  ## @param controller.image.csiProvisioner.digest csi-provisioner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param controller.image.csiProvisioner.pullPolicy csi-provisioner image pull policy
+  ## @param controller.image.csiProvisioner.pullSecrets csi-provisioner image pull secrets
+  ## @param controller.image.livenessProbe.registry liveness-probe image registry
+  ## @param controller.image.livenessProbe.repository liveness-probe image repository
+  ## @param controller.image.livenessProbe.tag liveness-probe image tag (immutable tags are recommended)
+  ## @param controller.image.livenessProbe.digest liveness-probe image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param controller.image.livenessProbe.pullPolicy liveness-probe image pull policy
+  ## @param controller.image.livenessProbe.pullSecrets liveness-probe image pull secrets
+  ## @param controller.image.hcloudCSIDriver.registry hcloud-csi-driver image registry
+  ## @param controller.image.hcloudCSIDriver.repository hcloud-csi-driver image repository
+  ## @param controller.image.hcloudCSIDriver.tag hcloud-csi-driver image tag (immutable tags are recommended)
+  ## @param controller.image.hcloudCSIDriver.digest hcloud-csi-driver image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param controller.image.hcloudCSIDriver.pullPolicy hcloud-csi-driver image pull policy
+  ## @param controller.image.hcloudCSIDriver.pullSecrets hcloud-csi-driver image pull secrets
+  ##
+  image:
+    csiAttacher:
+      registry: registry.k8s.io
+      repository: sig-storage/csi-attacher
+      tag: v4.1.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+
+    csiResizer:
+      registry: registry.k8s.io
+      repository: sig-storage/csi-resizer
+      tag: v1.7.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+
+    csiProvisioner:
+      registry: registry.k8s.io
+      repository: sig-storage/csi-provisioner
+      tag: v3.4.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    
+    livenessProbe:
+      registry: registry.k8s.io
+      repository: sig-storage/livenessprobe
+      tag: v2.9.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+
+    hcloudCSIDriver:
+      registry: docker.io
+      repository: hetznercloud/hcloud-csi-driver
+      tag: 2.2.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+
+  ## @param controller.replicaCount Number of controller replicas to deploy
+  ##
+  replicaCount: 2
+
+  ## @param controller.hcloudToken.value  Specifies the value for the hcloudToken. Creates a secret from that value. If you have already a hcloud token secret leave this empty.
+  ## @param controller.hcloudToken.extistingSecret.name Specifies the name of an existing Secret for the hcloud Token
+  ## @param controller.hcloudToken.extistingSecret.key Specifies the key of an existing Secret for the hcloud Token
+  ##
+  hcloudToken:
+    value: ""
+    extistingSecret:
+      name: hcloud
+      key: token
+
+  ## @param controller.hcloudVolumeDefaultLocation  Set this to the location of your cluster. If set the controller could run anywhere. If leave empty the controller needs to run on a hcloud node.
+  ##
+  hcloudVolumeDefaultLocation: ""
+
+  ## @param controller.containerPorts.metrics controller metrics container port
+  ## @param controller.containerPorts.healthz controller healthz container port
+  ##
+  containerPorts:
+    metrics: 9189
+    healthz: 9808
+
+  ## controller service parameters
+  ##
+  service:
+    ## @param controller.service.ports.metrics controller service metrics port
+    ports:
+      metrics: 9189
+    
+    ## @param controller.service.annotations Additional custom annotations for controller service
+    annotations: {}
+
+  ## RBAC configuration
+  ##
+  rbac:
+    ## @param controller.rbac.create Specifies whether RBAC resources should be created
+    ##
+    create: true
+    ## @param controller.rbac.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+
+  ## Configure extra options for controller containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param controller.livenessProbe.enabled Enable livenessProbe on controller containers
+  ## @param controller.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param controller.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param controller.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param controller.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param controller.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 2
+    timeoutSeconds: 3
+    failureThreshold: 5
+    successThreshold: 1
+
+  ## @param controller.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param controller.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param controller.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## controller resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param controller.resources.csiAttacher.limits The resources limits for the csiAttacher containers
+  ## @param controller.resources.csiAttacher.requests The requested resources for the csiAttacher containers
+  ## @param controller.resources.csiResizer.limits The resources limits for the csiResizer containers
+  ## @param controller.resources.csiResizer.requests The requested resources for the csiResizer containers
+  ## @param controller.resources.csiProvisioner.limits The resources limits for the csiProvisioner containers
+  ## @param controller.resources.csiProvisioner.requests The requested resources for the csiProvisioner containers
+  ## @param controller.resources.livenessProbe.limits The resources limits for the livenessProbe containers
+  ## @param controller.resources.livenessProbe.requests The requested resources for the livenessProbe containers
+  ## @param controller.resources.hcloudCSIDriver.limits The resources limits for the hcloudCSIDriver containers
+  ## @param controller.resources.hcloudCSIDriver.requests The requested resources for the hcloudCSIDriver containers
+  ##
+  resources:
+    csiAttacher:
+      limits: {}
+      requests: {}
+    csiResizer:
+      limits: {}
+      requests: {}
+    csiProvisioner:
+      limits: {}
+      requests: {}
+    livenessProbe:
+      limits: {}
+      requests: {}
+    hcloudCSIDriver:
+      limits: {}
+      requests: {}
+
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param controller.podSecurityContext.enabled Enabled controller pods' Security Context
+  ## @param controller.podSecurityContext.fsGroup Set controller pod's Security Context fsGroup
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+
+  ## @param controller.podLabels Extra labels for controller pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+
+  ## @param controller.podAnnotations Annotations for controller pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## @param controller.pdb.create Enable PodDisruptionBudged for controller pods
+  ## @param controller.pdb.minAvailable Set minAvailable for controller pods
+  ## @param controller.pdb.maxUnavailable Set maxUnavailable for controller pods
+  ##
+  pdb:
+    create: true
+    minAvailable: 1
+    maxUnavailable: ""
+
+  ## Autoscaling configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  ## @param controller.autoscaling.enabled Enable autoscaling for controller
+  ## @param controller.autoscaling.minReplicas Minimum number of controller replicas
+  ## @param controller.autoscaling.maxReplicas Maximum number of controller replicas
+  ## @param controller.autoscaling.targetCPU Target CPU utilization percentage
+  ## @param controller.autoscaling.targetMemory Target Memory utilization percentage
+  ##
+  autoscaling:
+    enabled: false
+    minReplicas: ""
+    maxReplicas: ""
+    targetCPU: ""
+    targetMemory: ""
+
+  ## @param controller.affinity Affinity for controller pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## @param controller.nodeSelector Node labels for controller pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## @param controller.tolerations Tolerations for controller pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## @param controller.updateStrategy.type controller statefulset strategy type
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    ## StrategyType
+    ## Can be set to RollingUpdate or OnDelete
+    ##
+    type: RollingUpdate
+
+  ## @param controller.priorityClassName controller pods' priorityClassName
+  ##
+  priorityClassName: ""
+
+  ## @param controller.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: []
+
+  ## @param controller.schedulerName Name of the k8s scheduler (other than default) for controller pods
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+
+  ## @param controller.terminationGracePeriodSeconds Seconds Redmine pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+
+  ## @param controller.lifecycleHooks for the controller container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+
+  ## @param controller.extraEnvVars Array with extra environment variables to add to controller nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+
+  ## @param controller.extraVolumes Extra Volumes for controller pods
+  extraVolumes: []
+
+  ## @param controller.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the controller container(s)
+  ##
+  extraVolumeMounts: []
+
+  ## @param controller.sidecars Add additional sidecar containers to the controller pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+
+  ## @param controller.initContainers Add additional init containers to the controller pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
+
+## @section Node Parameters
+##
+
+## Node
+##
+node:
+  ## @param node.image.CSINodeDriverRegistrar.registry csi-node-driver-registrar image registry
+  ## @param node.image.CSINodeDriverRegistrar.repository csi-node-driver-registrar image repository
+  ## @param node.image.CSINodeDriverRegistrar.tag csi-node-driver-registrar image tag (immutable tags are recommended)
+  ## @param node.image.CSINodeDriverRegistrar.digest csi-node-driver-registrar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param node.image.CSINodeDriverRegistrar.pullPolicy csi-node-driver-registrar image pull policy
+  ## @param node.image.CSINodeDriverRegistrar.pullSecrets csi-node-driver-registrar image pull secrets
+  ## @param node.image.livenessProbe.registry liveness-probe image registry
+  ## @param node.image.livenessProbe.repository liveness-probe image repository
+  ## @param node.image.livenessProbe.tag liveness-probe image tag (immutable tags are recommended)
+  ## @param node.image.livenessProbe.digest liveness-probe image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param node.image.livenessProbe.pullPolicy liveness-probe image pull policy
+  ## @param node.image.livenessProbe.pullSecrets liveness-probe image pull secrets
+  ## @param node.image.hcloudCSIDriver.registry hcloud-csi-driver image registry
+  ## @param node.image.hcloudCSIDriver.repository hcloud-csi-driver image repository
+  ## @param node.image.hcloudCSIDriver.tag hcloud-csi-driver image tag (immutable tags are recommended)
+  ## @param node.image.hcloudCSIDriver.digest hcloud-csi-driver image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param node.image.hcloudCSIDriver.pullPolicy hcloud-csi-driver image pull policy
+  ## @param node.image.hcloudCSIDriver.pullSecrets hcloud-csi-driver image pull secrets
+  ##
+  image:
+    CSINodeDriverRegistrar:
+      registry: registry.k8s.io
+      repository: sig-storage/csi-node-driver-registrar
+      tag: v2.7.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    
+    livenessProbe:
+      registry: registry.k8s.io
+      repository: sig-storage/livenessprobe
+      tag: v2.9.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+
+    hcloudCSIDriver:
+      registry: docker.io
+      repository: hetznercloud/hcloud-csi-driver
+      tag: 2.2.0
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+
+
+  ## @param node.containerPorts.metrics node Metrics container port
+  ## @param node.containerPorts.healthz node Health container port
+  ##
+  containerPorts:
+    metrics: 9189
+    healthz: 9808
+
+  ## node service parameters
+  ##
+  service:
+    ## @param node.service.ports.metrics node service Metrics port
+    ##
+    ports:
+      metrics: 9189
+    
+    ## @param node.service.annotations Additional custom annotations for node service
+    ##
+    annotations: {}
+
+
+  ## Configure extra options for node containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param node.livenessProbe.enabled Enable livenessProbe on node containers
+  ## @param node.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param node.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param node.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param node.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param node.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 2
+    timeoutSeconds: 3
+    failureThreshold: 5
+    successThreshold: 1
+
+  ## @param node.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+
+  ## @param node.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+
+  ## @param node.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+
+  ## node resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param node.resources.CSINodeDriverRegistrar.limits The resources limits for the CSINodeDriverRegistrar containers
+  ## @param node.resources.CSINodeDriverRegistrar.requests The requested resources for the CSINodeDriverRegistrar containers
+  ## @param node.resources.livenessProbe.limits The resources limits for the livenessProbe containers
+  ## @param node.resources.livenessProbe.requests The requested resources for the livenessProbe containers
+  ## @param node.resources.hcloudCSIDriver.limits The resources limits for the hcloudCSIDriver containers
+  ## @param node.resources.hcloudCSIDriver.requests The requested resources for the hcloudCSIDriver containers
+  ##
+  resources:
+    CSINodeDriverRegistrar:
+      limits: {}
+      requests: {}
+    livenessProbe:
+      limits: {}
+      requests: {}
+    hcloudCSIDriver:
+      limits: {}
+      requests: {}
+
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param node.podSecurityContext.enabled Enabled node pods' Security Context
+  ## @param node.podSecurityContext.fsGroup Set node pod's Security Context fsGroup
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+
+  ## @param node.hostNetwork Enables the hostNetwork
+  ##
+  hostNetwork: false
+
+  ## @param node.podLabels Extra labels for node pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+
+  ## @param node.podAnnotations Annotations for node pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## @param node.affinity Affinity for node pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: "instance.hetzner.cloud/is-root-server"
+    #         operator: NotIn
+    #         values:
+    #         - "true"
+
+  ## @param node.nodeSelector Node labels for node pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## @param node.tolerations Tolerations for node pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: {}
+    # - effect: NoExecute
+    #   operator: Exists
+    # - effect: NoSchedule
+    #   operator: Exists
+    # - key: CriticalAddonsOnly
+    #   operator: Exists
+
+  ## @param node.updateStrategy.type node statefulset strategy type
+  ## ref: https://kubernetes.io/docs/concepts/workloads/nodes/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    ## StrategyType
+    ## Can be set to RollingUpdate or OnDelete
+    ##
+    type: RollingUpdate
+
+  ## @param node.priorityClassName node pods' priorityClassName
+  ##
+  priorityClassName: ""
+
+  ## @param node.schedulerName Name of the k8s scheduler (other than default) for node pods
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+
+  ## @param node.terminationGracePeriodSeconds Seconds Redmine pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+
+  ## @param node.lifecycleHooks for the node container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+
+  ## @param node.extraVolumes Extra Volumes for controller pods
+  ##
+  extraVolumes: []
+
+  ## @param node.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the node container(s)
+  ##
+  extraVolumeMounts: []
+
+  ## @param node.sidecars Add additional sidecar containers to the node pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+
+  ## @param node.initContainers Add additional init containers to the node pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
+
+## @section Other Parameters
+##
+
+## ServiceAccount configuration
+##
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.annotations Additional Service Account annotations (evaluated as a template)
+  ##
+  annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+  ##
+  automountServiceAccountToken: true
+
+## Prometheus metrics
+##
+metrics:
+  ## @param metrics.enabled Enable the export of Prometheus metrics
+  ##
+  enabled: false
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace in which Prometheus is running
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.annotations Additional custom annotations for the ServiceMonitor
+    ##
+    annotations: {}
+    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
+    ##
+    jobLabel: ""
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## interval: 10s
+    ##
+    interval: ""
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## scrapeTimeout: 10s
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.relabelings Specify general relabeling
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    ## ref: https://github.com/syself/charts/tree/main/syself/prometheus-operator#prometheus-configuration
+    ## selector:
+    ##   prometheus: my-prometheus
+    ##
+    selector: {}
+
+## @param storageClasses Creates one or more storageClasses
+##
+storageClasses: {}
+# - name: standard
+#   defaultStorageClass: true
+#   reclaimPolicy: Retain


### PR DESCRIPTION
## What this PR does:
- Adds a helm chart for the hcloud-csi driver.
- Fixes #369 
- Adds the possibility to define own storageclasses
- Enable or disable Metrics and the use of a serviceMonitor Object
- Adds the possibility to add resources requests and limits to each container
- Adds an minimal production-ready example how to use the helm chart without monitoring 
- Adds documentation how to configure the helm chart

## Things to discuss
Currently, the helm chart is also available in the following repository: https://github.com/syself/charts. While it's possible to use the remote variant of the chart from there, we would like to contribute this helm chart to the "upstream" repository. However, this repository do not have a helm chart publishing process in place.

For the time being, I have left the chart as it is in our helm chart repository so that the community can use a hosted version. I would suggest to revisit this in the future once a publishing process for the helm chart in the csi-driver repository is implemented.