### PR TITLE
ci: fix goreleaser arguments

### DIFF
--- a/.github/workflows/publish_on_master.yml
+++ b/.github/workflows/publish_on_master.yml
@@ -35,6 +35,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: snapshot --rm-dist
+          args: release --snapshot --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes invalid arguments to `goreleaser`. Failed pipeline: https://github.com/hetznercloud/csi-driver/actions/runs/4666847571/jobs/8261917594#step:7:17

>    ⨯ command failed                                   error=unknown command "snapshot" for "goreleaser release"