### PR TITLE
test: verify against Kubernetes v1.27

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -11,11 +11,13 @@ jobs:
       matrix:
         include:
           - k3s: v1.24
-            k8s-test: v1.24.12
+            k8s-test: v1.24.13
           - k3s: v1.25
-            k8s-test: v1.25.8
+            k8s-test: v1.25.9
           - k3s: v1.26
-            k8s-test: v1.26.3
+            k8s-test: v1.26.4
+          - k3s: v1.27
+            k8s-test: v1.27.1
     name: k3s ${{ matrix.k3s }}
     steps:
     - uses: actions/setup-go@v2

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -182,6 +182,7 @@ related only to an unsupported version.
 
 | Kubernetes | CSI Driver |                                                                                   Deployment File |
 |------------|-----------:|--------------------------------------------------------------------------------------------------:|
+| 1.27       |      2.3.2 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml |
 | 1.26       |      2.3.2 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml |
 | 1.25       |      2.3.2 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml |
 | 1.24       |      2.3.2 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml |


### PR DESCRIPTION
Add tests for Kubernetes v1.27 and update other tests to latest patch releases.