### PR TITLE
fix: btrfs volumes can not be formatted (#421) [DO NOT MERGE]

### DIFF
--- a/test/e2e/kubernetes/testdriver-1.23.yaml
+++ b/test/e2e/kubernetes/testdriver-1.23.yaml
@@ -28,3 +28,4 @@ DriverInfo:
   SupportedFsType:
     ext4:
     xfs:
+    btrfs:

--- a/volumes/mount.go
+++ b/volumes/mount.go
@@ -212,6 +212,9 @@ func (s *LinuxMountService) FormatDisk(disk string, fstype string) error {
 	case "xfs":
 		_, _, err := command("mkfs.xfs", disk)
 		return err
+	case "btrfs":
+		_, _, err := command("mkfs.btrfs", disk)
+		return err
 	default:
 		return fmt.Errorf("unsupported disk format %s", fstype)
 	}


### PR DESCRIPTION
E2E Pipelines for forks are currently broken, so this is the same commit as #424 but in the repository. Do not merge, this PR is only to get some e2e test results.