### PR TITLE
ci: cleanup release-please after succesful release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,15 +17,6 @@ jobs:
           release-type: go
           package-name: csi-driver
 
-          # Manually set the bootstrap sha & release-as for the first release using release-please.
-          # The previous release pipeline created a new commit outside the `main` branch,
-          # so release-please has issues associated the newer releases and compares against
-          # 1.6.0 instead of 2.3.2. This commit is the on-branch commit for the 2.3.2 tag.
-          # TODO: Remove after the first release with release-please.
-          bootstrap-sha: 8ebf8140f2201f053c9c104344e0600736ec80dc
-          last-release-sha: 8ebf8140f2201f053c9c104344e0600736ec80dc
-          release-as: "2.4.0"
-
           extra-files: |
             driver/driver.go
             


### PR DESCRIPTION
Release v2.4.0 was successfully created. As we now have a good release, release-please will use that as the reference release for the future and we can remove all hardcoded references.
