### PR TITLE
ci: fix release-please issues with helm

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -176,7 +176,7 @@ spec:
             limits: {}
             requests: {}
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: IfNotPresent
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:
@@ -309,7 +309,7 @@ spec:
             name: socket-dir
 
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: IfNotPresent
           command: [/bin/hcloud-csi-driver-controller]
           env:

--- a/chart/.snapshots/example-prod.yaml
+++ b/chart/.snapshots/example-prod.yaml
@@ -245,7 +245,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: IfNotPresent
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:
@@ -420,7 +420,7 @@ spec:
             name: socket-dir
 
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: IfNotPresent
           command: [/bin/hcloud-csi-driver-controller]
           env:

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -293,7 +293,7 @@ spec:
               cpu: 12m
               memory: 22Mi
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: Always
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:
@@ -547,7 +547,7 @@ spec:
             name: socket-dir
 
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: Always
           command: [/bin/hcloud-csi-driver-controller]
           env:

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -131,7 +131,7 @@ spec:
             name: socket-dir
 
         - name: hcloud-csi-driver
-          image: {{ tpl .Values.controller.image.hcloudCSIDriver.name . }}
+          image: {{ tpl .Values.controller.image.hcloudCSIDriver.name . }} # x-release-please-version
           imagePullPolicy: {{ .Values.controller.image.hcloudCSIDriver.pullPolicy }}
           command: [/bin/hcloud-csi-driver-controller]
           env:

--- a/chart/templates/node/daemonset.yaml
+++ b/chart/templates/node/daemonset.yaml
@@ -99,7 +99,7 @@ spec:
           resources: {{- toYaml .Values.node.resources.livenessProbe | nindent 12 }}
           {{- end }}
         - name: hcloud-csi-driver
-          image: {{ tpl .Values.node.image.hcloudCSIDriver.name . }}
+          image: {{ tpl .Values.node.image.hcloudCSIDriver.name . }} # x-release-please-version
           imagePullPolicy: {{ .Values.node.image.hcloudCSIDriver.pullPolicy }}
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -7,9 +7,7 @@ metadata:
   namespace: "kube-system"
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
 automountServiceAccountToken: true
 ---
@@ -32,9 +30,7 @@ metadata:
   name: hcloud-csi-controller
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
 rules:
 # attacher
@@ -94,9 +90,7 @@ metadata:
   name: hcloud-csi-controller
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -115,9 +109,7 @@ metadata:
   namespace: "kube-system"
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
 spec:
   ports:
@@ -136,9 +128,7 @@ metadata:
   namespace: "kube-system"
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: node
 spec:
   ports:
@@ -157,9 +147,7 @@ metadata:
   namespace: "kube-system"
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: node
     app: hcloud-csi 
 spec:
@@ -172,9 +160,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: hcloud-csi
-        helm.sh/chart: hcloud-csi-2.4.0
         app.kubernetes.io/instance: hcloud-csi
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: node
         app: hcloud-csi
     spec:
@@ -222,7 +208,7 @@ spec:
             limits: {}
             requests: {}
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: IfNotPresent
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:
@@ -286,9 +272,7 @@ metadata:
   namespace: "kube-system"
   labels:
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.4.0
     app.kubernetes.io/instance: hcloud-csi
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
     app: hcloud-csi-controller 
 spec:
@@ -302,9 +286,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: hcloud-csi
-        helm.sh/chart: hcloud-csi-2.4.0
         app.kubernetes.io/instance: hcloud-csi
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
         app: hcloud-csi-controller
     spec:
@@ -360,7 +342,7 @@ spec:
             name: socket-dir
 
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
           imagePullPolicy: IfNotPresent
           command: [/bin/hcloud-csi-driver-controller]
           env:

--- a/hack/update-deployment-yamls.sh
+++ b/hack/update-deployment-yamls.sh
@@ -2,6 +2,7 @@
 set -ueo pipefail
 
 # Template the chart with pre-built values to get the legacy deployment files
+# Also remove labels that are Helm specific
 helm template hcloud-csi chart \
   --namespace kube-system \
   --set metrics.enabled=true \
@@ -9,4 +10,6 @@ helm template hcloud-csi chart \
   --set controller.podLabels.app=hcloud-csi-controller \
   --set node.matchLabelsOverride.app=hcloud-csi \
   --set node.podLabels.app=hcloud-csi \
+  | grep -v helm.sh/chart \
+  | grep -v app.kubernetes.io/managed-by \
   > deploy/kubernetes/hcloud-csi.yml


### PR DESCRIPTION
- two unecessary labels were added to the kubernetes manifests, these labels are helm specific/have a helm specific value.
- The image version in the rendered manifests did not update in the release-please PR, causing the manifests check to fail.

See https://github.com/hetznercloud/csi-driver/actions/runs/6339300867/job/17218138850?pr=493