### PR TITLE
ci: update version in all files that have release-please markers

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,10 @@ jobs:
 
           extra-files: |
             driver/driver.go
-            
+
             deploy/kubernetes/hcloud-csi.yml
-            deploy/kubernetes/controller/deployment.yaml
-            deploy/kubernetes/node/daemonset.yaml
+
             chart/Chart.yaml
-            chart/values.yaml
+            chart/.snapshots/example-prod.yaml
+            chart/.snapshots/full.yaml
+            chart/.snapshots/default.yaml


### PR DESCRIPTION
This was missing from #508.

List of files taken by grepping for the marker. We do not need to include the`chart/templates` files, because they dont actually have the version. The marker in those files is only so it shows up in the rendered manifests.
```shell
$ grep -Hri "x-release-please-version"
chart/Chart.yaml:version: 2.4.0 # x-release-please-version
chart/.snapshots/example-prod.yaml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
chart/.snapshots/example-prod.yaml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
chart/.snapshots/full.yaml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
chart/.snapshots/full.yaml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
chart/.snapshots/default.yaml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
chart/.snapshots/default.yaml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
chart/templates/controller/deployment.yaml:          image: {{ tpl .Values.controller.image.hcloudCSIDriver.name . }} # x-release-please-version
chart/templates/node/daemonset.yaml:          image: {{ tpl .Values.node.image.hcloudCSIDriver.name . }} # x-release-please-version
driver/driver.go:       PluginVersion = "2.4.0" // x-release-please-version
deploy/kubernetes/hcloud-csi.yml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
deploy/kubernetes/hcloud-csi.yml:          image: docker.io/hetznercloud/hcloud-csi-driver:v2.4.0 # x-release-please-version
```