### PR TITLE
fix: release workflow fails publishing with missing Git author

### DIFF
--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -28,6 +28,12 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Git is used to push helm chart to hetznercloud/helm-charts
+      - name: Setup Git
+        run: |
+          git config --global user.name hcloud-bot
+          git config --global user.email github-bot@hetzner-cloud.de
+
       - name: "make docker plugin"
         run: |
           cd deploy/docker-swarm/pkg


### PR DESCRIPTION
See https://github.com/hetznercloud/csi-driver/actions/runs/6347875350/job/17243530008#step:8:66

The v2.5.0 release did not go through. The intent is to publish this as v2.5.1 ASAP.