### PR TITLE
feat: add node.kubeletDir helm chart config value

### DIFF
--- a/chart/.snapshots/full.values.yaml
+++ b/chart/.snapshots/full.values.yaml
@@ -333,6 +333,8 @@ node:
       imagePullPolicy: Always
       command: [ 'sh', '-c', 'echo "hello world"' ]
 
+  kubeletDir: /var/lib/k0s/kubelet
+
 serviceAccount:
   annotations:
     service-account-annotation: service-account-annotation

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -264,7 +264,7 @@ spec:
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
           imagePullPolicy: Always
           args:
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
+            - --kubelet-registration-path=/var/lib/k0s/kubelet/plugins/csi.hetzner.cloud/socket
           volumeMounts:
             - name: plugin-dir
               mountPath: /run/csi
@@ -298,7 +298,7 @@ spec:
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:
             - name: kubelet-dir
-              mountPath: /var/lib/kubelet
+              mountPath: /var/lib/k0s/kubelet
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /run/csi
@@ -371,15 +371,15 @@ spec:
       volumes:
         - name: kubelet-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: /var/lib/k0s/kubelet
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            path: /var/lib/k0s/kubelet/plugins/csi.hetzner.cloud/
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: /var/lib/k0s/kubelet/plugins_registry/
             type: Directory
         - name: device-dir
           hostPath:

--- a/chart/templates/node/daemonset.yaml
+++ b/chart/templates/node/daemonset.yaml
@@ -77,7 +77,7 @@ spec:
           image: {{ tpl .Values.node.image.csiNodeDriverRegistrar.name . }}
           imagePullPolicy: {{ .Values.node.image.csiNodeDriverRegistrar.pullPolicy }}
           args:
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
+            - --kubelet-registration-path={{ .Values.node.kubeletDir }}/plugins/csi.hetzner.cloud/socket
           volumeMounts:
             - name: plugin-dir
               mountPath: /run/csi
@@ -104,7 +104,7 @@ spec:
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:
             - name: kubelet-dir
-              mountPath: /var/lib/kubelet
+              mountPath: {{ .Values.node.kubeletDir }}
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /run/csi
@@ -158,15 +158,15 @@ spec:
       volumes:
         - name: kubelet-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: {{ .Values.node.kubeletDir }}
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            path: {{ .Values.node.kubeletDir }}/plugins/csi.hetzner.cloud/
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ .Values.node.kubeletDir }}/plugins_registry/
             type: Directory
         - name: device-dir
           hostPath:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -539,6 +539,9 @@
                 "initContainers": {
                     "type": "array"
                 },
+                "kubeletDir": {
+                    "type": "string"
+                },
                 "lifecycleHooks": {
                     "type": "object"
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,7 +101,7 @@ controller:
       ##   - myRegistryKeySecretName
       ##
       pullSecrets: []
-    
+
     livenessProbe:
       name: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
       ## Specify a imagePullPolicy
@@ -165,7 +165,7 @@ controller:
     ## @param controller.service.ports.metrics controller service metrics port
     ports:
       metrics: 9189
-    
+
     ## @param controller.service.annotations Additional custom annotations for controller service
     annotations: {}
 
@@ -395,7 +395,7 @@ node:
       ##   - myRegistryKeySecretName
       ##
       pullSecrets: []
-    
+
     livenessProbe:
       name: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
       ## Specify a imagePullPolicy
@@ -443,7 +443,7 @@ node:
     ##
     ports:
       metrics: 9189
-    
+
     ## @param node.service.annotations Additional custom annotations for node service
     ##
     annotations: {}
@@ -620,6 +620,12 @@ node:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
+
+  ## @param node.kubeletDir Location of the /var/lib/kubelet directory as some k8s distribution differ from the standard.
+  ## e.g:
+  ## kubeletDir: /var/lib/k0s/kubelet
+  ##
+  kubeletDir: /var/lib/kubelet
 
 ## @section Other Parameters
 ##


### PR DESCRIPTION
This PR adds the config value node.kubeletDir to the helm chart to allow deploying the helm chart onto k8s distributions such as k0s. See e.g. #473 