### PR TITLE
docs(k8s): non-standard kubelet dir (k0s, microk8s)

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -622,9 +622,10 @@ node:
   initContainers: []
 
   ## @param node.kubeletDir Location of the /var/lib/kubelet directory as some k8s distribution differ from the standard.
-  ## e.g:
+  ## For k0s:
   ## kubeletDir: /var/lib/k0s/kubelet
-  ##
+  ## For microk8s:
+  ## kubeletDir: /var/snap/microk8s/common/var/lib/kubelet
   kubeletDir: /var/lib/kubelet
 
 ## @section Other Parameters

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -69,6 +69,16 @@
    kubectl exec -it my-csi-app -- /bin/sh
    ```
 
+### Alternative Kubelet Directory
+
+Some Kubernetes distributions use a non-standard path for the Kubelet directory.
+The csi-driver needs to know about this to successfully mount volumes. You can
+configure this through the Helm Chart Value `node.kubeletDir`.
+
+- Standard: `/var/lib/kubelet`
+- **k0s**: `/var/lib/k0s/kubelet`
+- **microk8s**: `/var/snap/microk8s/common/var/lib/kubelet`
+
 ### Volumes Encrypted with LUKS
 
 To add encryption with LUKS you have to create a dedicate secret containing an encryption passphrase and duplicate the default `hcloud-volumes` storage class with added parameters referencing this secret:


### PR DESCRIPTION
Add some explanation about the kubelet dir value so users have an easier time figuring this out.

Related to #534