### PR TITLE
feat: drop tests for kubernetes v1.25

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -16,14 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - k3s: v1.25
-            k8s-test: v1.25.13
           - k3s: v1.26
-            k8s-test: v1.26.8
+            k8s-test: v1.26.12
           - k3s: v1.27
-            k8s-test: v1.27.5
+            k8s-test: v1.27.9
           - k3s: v1.28
-            k8s-test: v1.28.1
+            k8s-test: v1.28.5
     steps:
     - uses: actions/setup-go@v5
       with:

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -206,10 +206,10 @@ related only to an unsupported version.
 
 | Kubernetes | CSI Driver |                                                                                   Deployment File |
 |------------|-----------:|--------------------------------------------------------------------------------------------------:|
-| 1.28       |     2.5.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.5.1/deploy/kubernetes/hcloud-csi.yml |
-| 1.27       |     2.5.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.5.1/deploy/kubernetes/hcloud-csi.yml |
-| 1.26       |     2.5.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.5.1/deploy/kubernetes/hcloud-csi.yml |
-| 1.25       |     2.5.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.5.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.28       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
+| 1.27       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
+| 1.26       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
+| 1.25       |      2.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.24       |      2.4.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.4.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.23       |      2.2.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.2.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.22       |      1.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml |

--- a/test/e2e/kubernetes/run-e2e-tests.sh
+++ b/test/e2e/kubernetes/run-e2e-tests.sh
@@ -13,7 +13,7 @@ ginkgo="${SCRIPT_DIR}/test-binaries/ginkgo"
 ginkgo_flags="-v --flakeAttempts=2"
 
 e2e="${SCRIPT_DIR}/test-binaries/e2e.test"
-e2e_flags="-storage.testdriver=${SCRIPT_DIR}/testdriver-1.25.yaml"
+e2e_flags="-storage.testdriver=${SCRIPT_DIR}/testdriver.yaml"
 
 echo "Executing parallel tests"
 ${ginkgo} ${ginkgo_flags} \

--- a/test/e2e/kubernetes/testdriver.yaml
+++ b/test/e2e/kubernetes/testdriver.yaml
@@ -6,9 +6,14 @@ DriverInfo:
     Max: 15Gi
     Min: 10Gi
   Capabilities:
+    # We set all capabilities from the lowest supported version of Kubernetes.
+    #
     # Available capabilities are defined in the kubernetes repositories, make
     # sure to select the corresponding k8s version:
-    # https://github.com/kubernetes/kubernetes/blob/release-1.25/test/e2e/storage/framework/testdriver.go#L150
+    # https://github.com/kubernetes/kubernetes/blob/release-1.26/test/e2e/storage/framework/testdriver.go#L150
+    #
+    # To get a list of new capabilities when upgrading, run this command in the kubernetes repository:
+    #   git diff origin/release-1.26 origin/release-1.27 -- test/e2e/storage/framework/testdriver.go
     persistence: true
     block: true
     fsGroup: true
@@ -26,6 +31,8 @@ DriverInfo:
     singleNodeVolume: true
     topology: true
     capacity: false
+    readWriteOncePod: false # https://github.com/hetznercloud/csi-driver/issues/327
+    multiplePVsSameID: true # No need to disable according to comment on CapMultiplePVsSameID
   SupportedFsType:
     ext4:
     xfs:


### PR DESCRIPTION
Kubernetes v1.25 is End of Life since 2023-10-28. In accordance with our Versioning policy.