### PR TITLE
ci: run tests on main to get coverage comparison

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Run tests
-on: [ pull_request ]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tests are currently only executed for PRs. This has two downsides:

- Coverage comparison in PRs is not available
- If two PRs modify similar code, they have the potential to break tests, this would only be discovered once a new PR is opened.