### PR TITLE
feat(chart): separate image name and tag

### DIFF
--- a/chart/templates/_common_images.tpl
+++ b/chart/templates/_common_images.tpl
@@ -3,7 +3,7 @@ Return the proper Container Image Name
 {{ include "common.images.image" (dict "value" .Values.controller.image.hcloudCSIDriver "context" $) }}
 */}}
 {{- define "common.images.image" -}}
-{{ .value.name }}{{ if .value.tag }}:{{ tpl .value.tag .context }}{{ end }}
+{{ tpl .value.name .context }}{{ if .value.tag }}:{{ tpl .value.tag .context }}{{ end }}
 {{- end -}}
 
 {{/*

--- a/chart/templates/_common_images.tpl
+++ b/chart/templates/_common_images.tpl
@@ -1,5 +1,5 @@
 {{/*
-Return the proper Container Image Name
+Return the Container Image Name
 {{ include "common.images.image" (dict "value" .Values.controller.image.hcloudCSIDriver "context" .) }}
 */}}
 {{- define "common.images.image" -}}

--- a/chart/templates/_common_images.tpl
+++ b/chart/templates/_common_images.tpl
@@ -1,4 +1,12 @@
 {{/*
+Return the proper Container Image Name
+{{ include "common.images.image" (dict "value" .Values.controller.image.hcloudCSIDriver "context" $) }}
+*/}}
+{{- define "common.images.image" -}}
+{{ .value.name }}{{ if .value.tag }}:{{ tpl .value.tag .context }}{{ end }}
+{{- end -}}
+
+{{/*
 Return the proper Container Image Registry Secret Names evaluating values as templates
 {{ include "common.images.pullSecrets" ( dict "images" (list .Values.path.to.the.image1 .Values.path.to.the.image2) "context" $) }}
 */}}

--- a/chart/templates/_common_images.tpl
+++ b/chart/templates/_common_images.tpl
@@ -1,6 +1,6 @@
 {{/*
 Return the proper Container Image Name
-{{ include "common.images.image" (dict "value" .Values.controller.image.hcloudCSIDriver "context" $) }}
+{{ include "common.images.image" (dict "value" .Values.controller.image.hcloudCSIDriver "context" .) }}
 */}}
 {{- define "common.images.image" -}}
 {{ tpl .value.name .context }}{{ if .value.tag }}:{{ tpl .value.tag .context }}{{ end }}

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         {{- end }}
       containers:
         - name: csi-attacher
-          image: {{ tpl .Values.controller.image.csiAttacher.name . }}
+          image: {{ include "common.images.image" (dict "value" .Values.controller.image.csiAttacher "context" .) }}
           imagePullPolicy: {{ .Values.controller.image.csiAttacher.pullPolicy }}
           {{- if .Values.controller.resources.csiAttacher }}
           resources: {{- toYaml .Values.controller.resources.csiAttacher | nindent 12 }}
@@ -89,7 +89,7 @@ spec:
             mountPath: /run/csi
 
         - name: csi-resizer
-          image: {{ tpl .Values.controller.image.csiResizer.name . }}
+          image: {{ include "common.images.image" (dict "value" .Values.controller.image.csiResizer "context" .) }}
           imagePullPolicy: {{ .Values.controller.image.csiResizer.pullPolicy }}
           {{- if .Values.controller.resources.csiResizer }}
           resources: {{- toYaml .Values.controller.resources.csiResizer | nindent 12 }}
@@ -104,7 +104,7 @@ spec:
             mountPath: /run/csi
 
         - name: csi-provisioner
-          image: {{ tpl .Values.controller.image.csiProvisioner.name . }}
+          image: {{ include "common.images.image" (dict "value" .Values.controller.image.csiProvisioner "context" .) }}
           imagePullPolicy: {{ .Values.controller.image.csiProvisioner.pullPolicy }}
           {{- if .Values.controller.resources.csiProvisioner }}
           resources: {{- toYaml .Values.controller.resources.csiProvisioner | nindent 12 }}
@@ -121,7 +121,7 @@ spec:
             mountPath: /run/csi
 
         - name: liveness-probe
-          image: {{ tpl .Values.controller.image.livenessProbe.name . }}
+          image: {{ include "common.images.image" (dict "value" .Values.controller.image.livenessProbe "context" .) }}
           imagePullPolicy: {{ .Values.controller.image.livenessProbe.pullPolicy }}
           {{- if .Values.controller.resources.livenessProbe }}
           resources: {{- toYaml .Values.controller.resources.livenessProbe | nindent 12 }}
@@ -131,7 +131,7 @@ spec:
             name: socket-dir
 
         - name: hcloud-csi-driver
-          image: {{ tpl .Values.controller.image.hcloudCSIDriver.name . }} # x-release-please-version
+          image: {{ include "common.images.image" (dict "value" .Values.controller.image.hcloudCSIDriver "context" .) }} # x-release-please-version
           imagePullPolicy: {{ .Values.controller.image.hcloudCSIDriver.pullPolicy }}
           command: [/bin/hcloud-csi-driver-controller]
           env:

--- a/chart/templates/node/daemonset.yaml
+++ b/chart/templates/node/daemonset.yaml
@@ -74,7 +74,7 @@ spec:
         {{- end }}
       containers:
         - name: csi-node-driver-registrar
-          image: {{ tpl .Values.node.image.csiNodeDriverRegistrar.name . }}
+          image: {{ include "common.images.image" (dict "value" .Values.node.image.csiNodeDriverRegistrar "context" .) }}
           imagePullPolicy: {{ .Values.node.image.csiNodeDriverRegistrar.pullPolicy }}
           args:
             - --kubelet-registration-path={{ .Values.node.kubeletDir }}/plugins/csi.hetzner.cloud/socket
@@ -90,7 +90,7 @@ spec:
           resources: {{- toYaml .Values.node.resources.csiNodeDriverRegistrar | nindent 12 }}
           {{- end }}
         - name: liveness-probe
-          image: {{ tpl .Values.node.image.livenessProbe.name . }}
+          image: {{ include "common.images.image" (dict "value" .Values.node.image.livenessProbe "context" .) }}
           imagePullPolicy: {{ .Values.node.image.livenessProbe.pullPolicy }}
           volumeMounts:
           - mountPath: /run/csi
@@ -99,7 +99,7 @@ spec:
           resources: {{- toYaml .Values.node.resources.livenessProbe | nindent 12 }}
           {{- end }}
         - name: hcloud-csi-driver
-          image: {{ tpl .Values.node.image.hcloudCSIDriver.name . }} # x-release-please-version
+          image: {{ include "common.images.image" (dict "value" .Values.node.image.hcloudCSIDriver "context" .) }} # x-release-please-version
           imagePullPolicy: {{ .Values.node.image.hcloudCSIDriver.pullPolicy }}
           command: [/bin/hcloud-csi-driver-node]
           volumeMounts:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -74,6 +74,9 @@
                                 "name": {
                                     "type": "string"
                                 },
+                                "tag": {
+                                    "type": "string"
+                                },
                                 "pullPolicy": {
                                     "type": "string"
                                 },
@@ -89,6 +92,9 @@
                             "type": "object",
                             "properties": {
                                 "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
                                     "type": "string"
                                 },
                                 "pullPolicy": {
@@ -108,6 +114,9 @@
                                 "name": {
                                     "type": "string"
                                 },
+                                "tag": {
+                                    "type": "string"
+                                },
                                 "pullPolicy": {
                                     "type": "string"
                                 },
@@ -123,6 +132,9 @@
                             "type": "object",
                             "properties": {
                                 "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
                                     "type": "string"
                                 },
                                 "pullPolicy": {
@@ -489,6 +501,9 @@
                                 "name": {
                                     "type": "string"
                                 },
+                                "tag": {
+                                    "type": "string"
+                                },
                                 "pullPolicy": {
                                     "type": "string"
                                 },
@@ -506,6 +521,9 @@
                                 "name": {
                                     "type": "string"
                                 },
+                                "tag": {
+                                    "type": "string"
+                                },
                                 "pullPolicy": {
                                     "type": "string"
                                 },
@@ -521,6 +539,9 @@
                             "type": "object",
                             "properties": {
                                 "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
                                     "type": "string"
                                 },
                                 "pullPolicy": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,25 +37,31 @@ commonAnnotations: {}
 ## Controller
 ##
 controller:
-  ## @param controller.image.csiAttacher.name full path to csi-attacher image (including tag/digest & registry)
+  ## @param controller.image.csiAttacher.name csi-attacher image name
+  ## @param controller.image.csiAttacher.tag csi-attacher image tag
   ## @param controller.image.csiAttacher.pullPolicy csi-attacher image pull policy
   ## @param controller.image.csiAttacher.pullSecrets csi-attacher image pull secrets
-  ## @param controller.image.csiResizer.name full path to csi-resizer image (including tag/digest & registry)
+  ## @param controller.image.csiResizer.name csi-resizer image name
+  ## @param controller.image.csiResizer.tag csi-resizer image tag
   ## @param controller.image.csiResizer.pullPolicy csi-resizer image pull policy
   ## @param controller.image.csiResizer.pullSecrets csi-resizer image pull secrets
-  ## @param controller.image.csiProvisioner.name full path to csi-provisioner image (including tag/digest & registry)
+  ## @param controller.image.csiProvisioner.name csi-provisioner image name
+  ## @param controller.image.csiProvisioner.tag csi-provisioner image tag
   ## @param controller.image.csiProvisioner.pullPolicy csi-provisioner image pull policy
   ## @param controller.image.csiProvisioner.pullSecrets csi-provisioner image pull secrets
-  ## @param controller.image.livenessProbe.name full path to liveness-probe image (including tag/digest & registry)
+  ## @param controller.image.livenessProbe.name liveness-probe image name
+  ## @param controller.image.livenessProbe.tag liveness-probe image tag
   ## @param controller.image.livenessProbe.pullPolicy liveness-probe image pull policy
   ## @param controller.image.livenessProbe.pullSecrets liveness-probe image pull secrets
-  ## @param controller.image.hcloudCSIDriver.name full path to hcloud-csi-driver image (including tag/digest & registry)
+  ## @param controller.image.hcloudCSIDriver.name hcloud-csi-driver image name
+  ## @param controller.image.hcloudCSIDriver.tag hcloud-csi-driver image tag
   ## @param controller.image.hcloudCSIDriver.pullPolicy hcloud-csi-driver image pull policy
   ## @param controller.image.hcloudCSIDriver.pullSecrets hcloud-csi-driver image pull secrets
   ##
   image:
     csiAttacher:
-      name: registry.k8s.io/sig-storage/csi-attacher:v4.1.0
+      name: registry.k8s.io/sig-storage/csi-attacher
+      tag: v4.1.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -71,7 +77,8 @@ controller:
       pullSecrets: []
 
     csiResizer:
-      name: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+      name: registry.k8s.io/sig-storage/csi-resizer
+      tag: v1.7.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -87,7 +94,8 @@ controller:
       pullSecrets: []
 
     csiProvisioner:
-      name: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+      name: registry.k8s.io/sig-storage/csi-provisioner
+      tag: v3.4.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -103,7 +111,8 @@ controller:
       pullSecrets: []
 
     livenessProbe:
-      name: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+      name: registry.k8s.io/sig-storage/livenessprobe
+      tag: v2.9.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -119,7 +128,8 @@ controller:
       pullSecrets: []
 
     hcloudCSIDriver:
-      name: docker.io/hetznercloud/hcloud-csi-driver:v{{ .Chart.Version }}
+      name: docker.io/hetznercloud/hcloud-csi-driver
+      tag: v{{ .Chart.Version }}
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -371,19 +381,23 @@ controller:
 ## Node
 ##
 node:
-  ## @param node.image.csiNodeDriverRegistrar.name full path to csi-node-driver-registrar image (including tag/digest & registry)
+  ## @param node.image.csiNodeDriverRegistrar.name csi-node-driver-registrar image name
+  ## @param node.image.csiNodeDriverRegistrar.tag csi-node-driver-registrar image tag
   ## @param node.image.csiNodeDriverRegistrar.pullPolicy csi-node-driver-registrar image pull policy
   ## @param node.image.csiNodeDriverRegistrar.pullSecrets csi-node-driver-registrar image pull secrets
-  ## @param node.image.livenessProbe.name full path to liveness-probe image (including tag/digest & registry)
+  ## @param node.image.livenessProbe.name liveness-probe image name
+  ## @param node.image.livenessProbe.tag liveness-probe image tag
   ## @param node.image.livenessProbe.pullPolicy liveness-probe image pull policy
   ## @param node.image.livenessProbe.pullSecrets liveness-probe image pull secrets
-  ## @param node.image.hcloudCSIDriver.name full path to hcloud-csi-driver image (including tag/digest & registry)
+  ## @param node.image.hcloudCSIDriver.name hcloud-csi-driver image name
+  ## @param node.image.hcloudCSIDriver.tag hcloud-csi-driver image tag
   ## @param node.image.hcloudCSIDriver.pullPolicy hcloud-csi-driver image pull policy
   ## @param node.image.hcloudCSIDriver.pullSecrets hcloud-csi-driver image pull secrets
   ##
   image:
     csiNodeDriverRegistrar:
-      name: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
+      name: registry.k8s.io/sig-storage/csi-node-driver-registrar
+      tag: v2.7.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -399,7 +413,8 @@ node:
       pullSecrets: []
 
     livenessProbe:
-      name: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+      name: registry.k8s.io/sig-storage/livenessprobe
+      tag: v2.9.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -415,7 +430,8 @@ node:
       pullSecrets: []
 
     hcloudCSIDriver:
-      name: docker.io/hetznercloud/hcloud-csi-driver:v{{ .Chart.Version }}
+      name: docker.io/hetznercloud/hcloud-csi-driver
+      tag: v{{ .Chart.Version }}
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
This change allows the user to configure the image name separately from the image tag.

This is useful if you only want to change the image path (e.g. private image proxy) and not the tag.

The use of `.tag` is optional and will only be added is a value is set to maintain backward compatibility.