### PR TITLE
feat: read HCLOUD_TOKEN from file

### DIFF
--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -153,6 +153,9 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: HCLOUD_TOKEN
+              {{- if .Values.controller.hcloudToken.file }}
+              value: {{ printf "file:%s" .Values.controller.hcloudToken.file | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.controller.hcloudToken.value }}
@@ -162,6 +165,7 @@ spec:
                   name: {{ .Values.controller.hcloudToken.existingSecret.name }}
                   key: {{ .Values.controller.hcloudToken.existingSecret.key }}
                   {{- end }}
+              {{- end }}
             {{- if .Values.controller.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -152,10 +152,11 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if .Values.controller.hcloudToken.file }}
+            - name: HCLOUD_TOKEN_FILE
+              value: {{ .Values.controller.hcloudToken.file | quote }}
+            {{- else }}
             - name: HCLOUD_TOKEN
-              {{- if .Values.controller.hcloudToken.file }}
-              value: {{ printf "file:%s" .Values.controller.hcloudToken.file | quote }}
-              {{- else }}
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.controller.hcloudToken.value }}
@@ -165,7 +166,7 @@ spec:
                   name: {{ .Values.controller.hcloudToken.existingSecret.name }}
                   key: {{ .Values.controller.hcloudToken.existingSecret.key }}
                   {{- end }}
-              {{- end }}
+            {{- end }}
             {{- if .Values.controller.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -139,11 +139,13 @@ controller:
   replicaCount: 1
 
   ## @param controller.hcloudToken.value  Specifies the value for the hcloudToken. Creates a secret from that value. If you have already a hcloud token secret leave this empty.
+  ## @param controller.hcloudToken.file Specifies the file path for the hcloudToken. The file must be provided externally (e.g. via secret agent injection). If you want to use a Kubernetes secret, leave this empty.
   ## @param controller.hcloudToken.existingSecret.name Specifies the name of an existing Secret for the hcloud Token
   ## @param controller.hcloudToken.existingSecret.key Specifies the key of an existing Secret for the hcloud Token
   ##
   hcloudToken:
     value: ""
+    file: ""
     existingSecret:
       name: hcloud
       key: token

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -106,6 +106,14 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger log.Logger)
 		return nil, errors.New("you need to provide an API token via the HCLOUD_TOKEN env var")
 	}
 
+	if strings.HasPrefix(apiToken, "file:") {
+		apiTokenBytes, err := os.ReadFile(strings.TrimPrefix(apiToken, "file:"))
+		if err != nil {
+			return nil, errors.New("failed to read HCLOUD_TOKEN from file: " + err.Error())
+		}
+		apiToken = string(apiTokenBytes)
+	}
+
 	if len(apiToken) != 64 {
 		return nil, errors.New("entered token is invalid (must be exactly 64 characters long)")
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -111,7 +111,7 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger log.Logger)
 		if err != nil {
 			return nil, errors.New("failed to read HCLOUD_TOKEN from file: " + err.Error())
 		}
-		apiToken = string(apiTokenBytes)
+		apiToken = strings.TrimSpace(string(apiTokenBytes))
 	}
 
 	if len(apiToken) != 64 {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -107,11 +107,11 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger log.Logger)
 	if !ok {
 		filepath, ok := os.LookupEnv("HCLOUD_TOKEN_FILE")
 		if !ok {
-			return nil, errors.New("you need to provide an API token via the HCLOUD_TOKEN or HCLOUD_TOKEN_FILE env var")
+			return nil, fmt.Errorf("you need to provide an API token via the HCLOUD_TOKEN or HCLOUD_TOKEN_FILE env var")
 		}
 		apiTokenBytes, err := os.ReadFile(filepath)
 		if err != nil {
-			return nil, errors.New("failed to read HCLOUD_TOKEN_FILE: " + err.Error())
+			return nil, fmt.Errorf("failed to read HCLOUD_TOKEN_FILE: %w", err)
 		}
 		apiToken = strings.TrimSpace(string(apiTokenBytes))
 	}


### PR DESCRIPTION
This allows the `HCLOUD_TOKEN` to be read from a file. This can be useful if the token is injected using secret injection (e.g. with the vault agent injector).

I tested the changes on my dev cluster. If someone is interested in using this with the vault agent injector, I used the following helm values:

```yaml
controller:
  hcloudToken:
    file: /vault/secrets/token
  image:
    hcloudCSIDriver:
      name: "" # path to custom image (because these changes here are not released)
  # add the same permissions that are used by system:auth-delegator role
  rbac:
    rules:
      - apiGroups:
          - authorization.k8s.io
        resources:
          - subjectaccessreviews
        verbs:
          - create
      - apiGroups:
          - authentication.k8s.io
        resources:
          - tokenreviews
        verbs:
          - create
  podAnnotations:
    vault.hashicorp.com/agent-inject: "true"
    vault.hashicorp.com/log-format: json
    vault.hashicorp.com/role: <your-vault-role-name>
    vault.hashicorp.com/secret-volume-path-token: /vault/secrets
    vault.hashicorp.com/agent-inject-file-token: token
    vault.hashicorp.com/agent-inject-secret-token: <your-vault-mount>/data/<your-vault-path>
    vault.hashicorp.com/agent-inject-template-token: |
      {{`{{ with secret "<your-vault-mount>/data/<your-vault-path>" -}}`}}
        {{`{{ .Data.data.token }}`}}
      {{`{{- end }}`}}
```

This change is inspired from [external-dns cloudflare provider](https://github.com/kubernetes-sigs/external-dns/blob/master/provider/cloudflare/cloudflare.go#L171). I requested the same change for the [hcloud-cloud-controller-manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/652) to keep consistency in reading HCLOUD_TOKEN from file.