### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ hcloud ssh-key create --name ssh-key-csi-test --public-key-from-file ~/.ssh/id_r
 
 2. Create a server
 ```
-hcloud server create --name csi-test-server --image ubuntu-20.04 --ssh-key ssh-key-csi-test --type cx11 
+hcloud server create --name csi-test-server --image ubuntu-20.04 --ssh-key ssh-key-csi-test --type cx22 
 ```
 
 3. Setup k3s on this server

--- a/hack/dev-up.sh
+++ b/hack/dev-up.sh
@@ -21,7 +21,7 @@ if [[ -n "${DEBUG:-}" ]]; then set -x; fi
 
   image_name=${IMAGE_NAME:-ubuntu-20.04}
   instance_count=${INSTANCES:-3}
-  instance_type=${INSTANCE_TYPE:-cx22}
+  instance_type=${INSTANCE_TYPE:-cpx11}
   location=${LOCATION:-fsn1}
   network_zone=${NETWORK_ZONE:-eu-central}
   ssh_keys=${SSH_KEYS:-}

--- a/hack/dev-up.sh
+++ b/hack/dev-up.sh
@@ -21,7 +21,7 @@ if [[ -n "${DEBUG:-}" ]]; then set -x; fi
 
   image_name=${IMAGE_NAME:-ubuntu-20.04}
   instance_count=${INSTANCES:-3}
-  instance_type=${INSTANCE_TYPE:-cpx11}
+  instance_type=${INSTANCE_TYPE:-cx22}
   location=${LOCATION:-fsn1}
   network_zone=${NETWORK_ZONE:-eu-central}
   ssh_keys=${SSH_KEYS:-}


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated

- Updated docs with newer server types
