### PR TITLE
fix(resize): recover from part-way failed resizes

### DIFF
--- a/api/volume.go
+++ b/api/volume.go
@@ -356,42 +356,29 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 
 	hcloudVolume, _, err := s.client.Volume.GetByID(ctx, volume.ID)
 	if err != nil {
-		level.Info(logger).Log(
-			"msg", "failed to get volume",
-			"err", err,
-		)
+		level.Info(logger).Log("msg", "failed to get volume", "err", err)
 		return err
 	}
 	if hcloudVolume == nil {
-		level.Info(logger).Log(
-			"msg", "volume to resize not found",
-		)
+		level.Info(logger).Log("msg", "volume to resize not found")
 		return volumes.ErrVolumeNotFound
 	}
 
 	logger = log.With(logger, "current-size", hcloudVolume.Size)
 
 	if hcloudVolume.Size >= size {
-		level.Info(logger).Log(
-			"msg", "volume already has a size larger or equal than the request",
-		)
+		level.Info(logger).Log("msg", "volume already has a size larger or equal than the request")
 		return volumes.ErrVolumeAlreadyFulfillsSizeRequirement
 	}
 
 	action, _, err := s.client.Volume.Resize(ctx, hcloudVolume, size)
 	if err != nil {
-		level.Info(logger).Log(
-			"msg", "failed to resize volume",
-			"err", err,
-		)
+		level.Info(logger).Log("msg", "failed to resize volume", "err", err)
 		return err
 	}
 
 	if err = s.client.Action.WaitFor(ctx, action); err != nil {
-		level.Info(logger).Log(
-			"msg", "failed to resize volume",
-			"err", err,
-		)
+		level.Info(logger).Log("msg", "failed to resize volume", "err", err)
 		return err
 	}
 	return nil

--- a/api/volume.go
+++ b/api/volume.go
@@ -367,8 +367,8 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 	logger = log.With(logger, "current-size", hcloudVolume.Size)
 
 	if hcloudVolume.Size >= size {
-		level.Info(logger).Log("msg", "volume already has a size larger or equal than the request")
-		return volumes.ErrVolumeAlreadyFulfillsSizeRequirement
+		level.Info(logger).Log("msg", "volume size is already larger or equal than the requested size")
+		return volumes.ErrVolumeSizeAlreadyReached
 	}
 
 	action, _, err := s.client.Volume.Resize(ctx, hcloudVolume, size)

--- a/api/volume.go
+++ b/api/volume.go
@@ -345,45 +345,51 @@ func (s *VolumeService) Detach(ctx context.Context, volume *csi.Volume, server *
 }
 
 func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int) error {
-	level.Info(s.logger).Log(
-		"msg", "resize volume",
+	logger := log.With(s.logger,
 		"volume-id", volume.ID,
 		"requested-size", size,
 	)
 
+	level.Info(logger).Log(
+		"msg", "resize volume",
+	)
+
 	hcloudVolume, _, err := s.client.Volume.GetByID(ctx, volume.ID)
 	if err != nil {
-		level.Info(s.logger).Log(
+		level.Info(logger).Log(
 			"msg", "failed to get volume",
-			"volume-id", volume.ID,
 			"err", err,
 		)
 		return err
 	}
 	if hcloudVolume == nil {
-		level.Info(s.logger).Log(
+		level.Info(logger).Log(
 			"msg", "volume to resize not found",
-			"volume-id", volume.ID,
 		)
 		return volumes.ErrVolumeNotFound
 	}
 
+	logger = log.With(logger, "current-size", hcloudVolume.Size)
+
+	if hcloudVolume.Size >= size {
+		level.Info(logger).Log(
+			"msg", "volume already has a size larger or equal than the request",
+		)
+		return volumes.ErrVolumeAlreadyFulfillsSizeRequirement
+	}
+
 	action, _, err := s.client.Volume.Resize(ctx, hcloudVolume, size)
 	if err != nil {
-		level.Info(s.logger).Log(
+		level.Info(logger).Log(
 			"msg", "failed to resize volume",
-			"volume-id", volume.ID,
-			"size", size,
 			"err", err,
 		)
 		return err
 	}
 
-	if err := s.client.Action.WaitFor(ctx, action); err != nil {
-		level.Info(s.logger).Log(
+	if err = s.client.Action.WaitFor(ctx, action); err != nil {
+		level.Info(logger).Log(
 			"msg", "failed to resize volume",
-			"volume-id", volume.ID,
-			"size", size,
 			"err", err,
 		)
 		return err

--- a/api/volume_test.go
+++ b/api/volume_test.go
@@ -35,7 +35,7 @@ func makeTestVolumeService(t *testing.T, requests []mocked.Request) (*VolumeServ
 }
 
 func TestResize(t *testing.T) {
-	t.Run("ErrVolumeAlreadyFulfillsSizeRequirement", func(t *testing.T) {
+	t.Run("ErrVolumeSizeAlreadyReached", func(t *testing.T) {
 		t.Run("happy with larger volume size", func(t *testing.T) {
 			volumeService, cleanup := makeTestVolumeService(t, []mocked.Request{
 				{
@@ -72,7 +72,7 @@ func TestResize(t *testing.T) {
 			defer cleanup()
 
 			err := volumeService.Resize(context.Background(), &csi.Volume{ID: 1}, 15)
-			assert.Equal(t, volumes.ErrVolumeAlreadyFulfillsSizeRequirement, err)
+			assert.Equal(t, volumes.ErrVolumeSizeAlreadyReached, err)
 		})
 
 		t.Run("with smaller volume size", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestResize(t *testing.T) {
 			defer cleanup()
 
 			err := volumeService.Resize(context.Background(), &csi.Volume{ID: 1}, 10)
-			assert.Equal(t, volumes.ErrVolumeAlreadyFulfillsSizeRequirement, err)
+			assert.Equal(t, volumes.ErrVolumeSizeAlreadyReached, err)
 		})
 	})
 }

--- a/api/volume_test.go
+++ b/api/volume_test.go
@@ -1,7 +1,94 @@
 package api
 
 import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/csi-driver/csi"
+	"github.com/hetznercloud/csi-driver/internal/mocked"
 	"github.com/hetznercloud/csi-driver/volumes"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var _ volumes.Service = (*VolumeService)(nil)
+
+func makeTestVolumeService(t *testing.T, requests []mocked.Request) (*VolumeService, func()) {
+	t.Helper()
+
+	testServer := httptest.NewServer(mocked.Handler(t, requests))
+
+	testClient := hcloud.NewClient(
+		hcloud.WithEndpoint(testServer.URL),
+		hcloud.WithBackoffFunc(func(_ int) time.Duration { return 0 }),
+		hcloud.WithPollBackoffFunc(func(_ int) time.Duration { return 0 }),
+	)
+
+	volumeService := NewVolumeService(log.NewNopLogger(), testClient)
+
+	return volumeService, testServer.Close
+}
+
+func TestResize(t *testing.T) {
+	t.Run("ErrVolumeAlreadyFulfillsSizeRequirement", func(t *testing.T) {
+		t.Run("happy with larger volume size", func(t *testing.T) {
+			volumeService, cleanup := makeTestVolumeService(t, []mocked.Request{
+				{
+					Method: "GET", Path: "/volumes/1",
+					Status: 200,
+					JSON: schema.VolumeGetResponse{
+						Volume: schema.Volume{ID: 1, Name: "pvc-123", Size: 10},
+					},
+				},
+				{
+					Method: "POST", Path: "/volumes/1/actions/resize",
+					Status: 201,
+					JSON: schema.VolumeActionResizeVolumeResponse{
+						Action: schema.Action{ID: 3, Status: "success"},
+					},
+				},
+			})
+			defer cleanup()
+
+			err := volumeService.Resize(context.Background(), &csi.Volume{ID: 1}, 15)
+			assert.NoError(t, err)
+		})
+
+		t.Run("with equal volume size", func(t *testing.T) {
+			volumeService, cleanup := makeTestVolumeService(t, []mocked.Request{
+				{
+					Method: "GET", Path: "/volumes/1",
+					Status: 200,
+					JSON: schema.VolumeGetResponse{
+						Volume: schema.Volume{ID: 1, Name: "pvc-123", Size: 15},
+					},
+				},
+			})
+			defer cleanup()
+
+			err := volumeService.Resize(context.Background(), &csi.Volume{ID: 1}, 15)
+			assert.Equal(t, volumes.ErrVolumeAlreadyFulfillsSizeRequirement, err)
+		})
+
+		t.Run("with smaller volume size", func(t *testing.T) {
+			volumeService, cleanup := makeTestVolumeService(t, []mocked.Request{
+				{
+					Method: "GET", Path: "/volumes/1",
+					Status: 200,
+					JSON: schema.VolumeGetResponse{
+						Volume: schema.Volume{ID: 1, Name: "pvc-123", Size: 15},
+					},
+				},
+			})
+			defer cleanup()
+
+			err := volumeService.Resize(context.Background(), &csi.Volume{ID: 1}, 10)
+			assert.Equal(t, volumes.ErrVolumeAlreadyFulfillsSizeRequirement, err)
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hetznercloud/hcloud-go/v2 v2.8.0
 	github.com/kubernetes-csi/csi-test/v5 v5.2.0
 	github.com/prometheus/client_golang v1.19.1
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.21.0
 	google.golang.org/grpc v1.64.0
 	k8s.io/mount-utils v0.29.4
@@ -20,6 +21,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.1 // indirect
 	github.com/onsi/gomega v1.30.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
-github.com/hetznercloud/hcloud-go/v2 v2.7.2 h1:UlE7n1GQZacCfyjv9tDVUN7HZfOXErPIfM/M039u9A0=
-github.com/hetznercloud/hcloud-go/v2 v2.7.2/go.mod h1:49tIV+pXRJTUC7fbFZ03s45LKqSQdOPP5y91eOnJo/k=
 github.com/hetznercloud/hcloud-go/v2 v2.8.0 h1:vfbfL/JfV8dIZUX7ANHWEbKNqgFWsETqvt/EctvoFJ0=
 github.com/hetznercloud/hcloud-go/v2 v2.8.0/go.mod h1:jvpP3qAWMIZ3WQwQLYa97ia6t98iPCgsJNwRts+Jnrk=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -77,8 +75,6 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=
-github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdURP+DABIEIjnmDdp+k=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -140,10 +136,6 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
-golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -170,8 +162,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de h1:cZGRis4/ot9uVm639a+rHCUaG0JJHEsdyzSQTMX+suY=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de/go.mod h1:H4O17MA/PE9BsGx3w+a+W2VOLLD1Qf7oJneAoU6WktY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 h1:NnYq6UN9ReLM9/Y01KWNOWyI5xQ9kbIms5GGJVwS/Yc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -179,8 +169,6 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
-google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
-google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
 google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
@@ -203,7 +191,5 @@ k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/mount-utils v0.29.4 h1:tW/URea4gtXlaVW7VObr52NQhS+z3SXTg1GUaFZjRL4=
 k8s.io/mount-utils v0.29.4/go.mod h1:SHUMR9n3b6tLgEmlyT36cL6fV6Sjwa5CJhc0guCXvb0=
-k8s.io/utils v0.0.0-20240423183400-0849a56e8f22 h1:ao5hUqGhsqdm+bYbjH/pRkCs0unBGe9UyDahzs9zQzQ=
-k8s.io/utils v0.0.0-20240423183400-0849a56e8f22/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 h1:jgGTlFYnhF1PM1Ax/lAlxUPE+KfCIXHaathvJg1C3ak=
 k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/internal/mocked/mocked.go
+++ b/internal/mocked/mocked.go
@@ -1,0 +1,54 @@
+package mocked
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Request struct {
+	Method     string
+	Path       string
+	PathRegexp string
+
+	Status int
+	Body   string
+	JSON   any
+}
+
+func Handler(t *testing.T, requests []Request) http.HandlerFunc {
+	t.Helper()
+
+	index := 0
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if index >= len(requests) {
+			t.Fatalf("received unknown request %d", index)
+		}
+
+		response := requests[index]
+		assert.Equal(t, response.Method, r.Method)
+		if response.PathRegexp != "" {
+			require.Regexp(t, response.Path, r.RequestURI, "request %d", index)
+		} else {
+			require.Equal(t, response.Path, r.RequestURI, "request %d", index)
+		}
+
+		w.WriteHeader(response.Status)
+		w.Header().Set("Content-Type", "application/json")
+		if response.Body != "" {
+			_, err := w.Write([]byte(response.Body))
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else if response.JSON != nil {
+			if err := json.NewEncoder(w).Encode(response.JSON); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		index++
+	})
+}

--- a/volumes/idempotency.go
+++ b/volumes/idempotency.go
@@ -157,7 +157,7 @@ func (s *IdempotentService) Detach(ctx context.Context, volume *csi.Volume, serv
 
 func (s *IdempotentService) Resize(ctx context.Context, volume *csi.Volume, size int) error {
 	switch err := s.volumeService.Resize(ctx, volume, size); err {
-	case ErrVolumeAlreadyFulfillsSizeRequirement:
+	case ErrVolumeSizeAlreadyReached:
 		// If a previous rescale attempt failed (rate limit, network connectivity, ...), the volume might already have the target size.
 		// In the Hetzner Cloud API, a resize must always be larger than the current size, so this
 		// would manifest as a "volume size is too small (invalid_input)" error.

--- a/volumes/idempotency.go
+++ b/volumes/idempotency.go
@@ -156,5 +156,15 @@ func (s *IdempotentService) Detach(ctx context.Context, volume *csi.Volume, serv
 }
 
 func (s *IdempotentService) Resize(ctx context.Context, volume *csi.Volume, size int) error {
-	return s.volumeService.Resize(ctx, volume, size)
+	switch err := s.volumeService.Resize(ctx, volume, size); err {
+	case ErrVolumeAlreadyFulfillsSizeRequirement:
+		// If a previous rescale attempt failed (rate limit, network connectivity, ...), the volume might already have the target size.
+		// In the Hetzner Cloud API, a resize must always be larger than the current size, so this
+		// would manifest as a "volume size is too small (invalid_input)" error.
+		return nil
+	case nil:
+		return nil
+	default:
+		return err
+	}
 }

--- a/volumes/idempotency_test.go
+++ b/volumes/idempotency_test.go
@@ -373,10 +373,10 @@ func TestIdempotentServiceDetachAttachedToDifferentServer(t *testing.T) {
 }
 
 func TestIdempotentServiceExpand(t *testing.T) {
-	t.Run("ErrVolumeAlreadyFulfillsSizeRequirement", func(t *testing.T) {
+	t.Run("ErrVolumeSizeAlreadyReached", func(t *testing.T) {
 		volumeService := &mock.VolumeService{
 			ResizeFunc: func(ctx context.Context, volume *csi.Volume, size int) error {
-				return volumes.ErrVolumeAlreadyFulfillsSizeRequirement
+				return volumes.ErrVolumeSizeAlreadyReached
 			},
 		}
 

--- a/volumes/idempotency_test.go
+++ b/volumes/idempotency_test.go
@@ -371,3 +371,20 @@ func TestIdempotentServiceDetachAttachedToDifferentServer(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIdempotentServiceExpand(t *testing.T) {
+	t.Run("ErrVolumeAlreadyFulfillsSizeRequirement", func(t *testing.T) {
+		volumeService := &mock.VolumeService{
+			ResizeFunc: func(ctx context.Context, volume *csi.Volume, size int) error {
+				return volumes.ErrVolumeAlreadyFulfillsSizeRequirement
+			},
+		}
+
+		service := volumes.NewIdempotentService(log.NewNopLogger(), volumeService)
+
+		err := service.Resize(context.Background(), &csi.Volume{}, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/volumes/service.go
+++ b/volumes/service.go
@@ -8,14 +8,14 @@ import (
 )
 
 var (
-	ErrVolumeNotFound                       = errors.New("volume not found")
-	ErrVolumeAlreadyExists                  = errors.New("volume does already exist")
-	ErrServerNotFound                       = errors.New("server not found")
-	ErrAttached                             = errors.New("volume is attached")
-	ErrNotAttached                          = errors.New("volume is not attached")
-	ErrAttachLimitReached                   = errors.New("max number of attachments per server reached")
-	ErrLockedServer                         = errors.New("server is locked")
-	ErrVolumeAlreadyFulfillsSizeRequirement = errors.New("volume already has a size larger or equal than the request")
+	ErrVolumeNotFound           = errors.New("volume not found")
+	ErrVolumeAlreadyExists      = errors.New("volume does already exist")
+	ErrServerNotFound           = errors.New("server not found")
+	ErrAttached                 = errors.New("volume is attached")
+	ErrNotAttached              = errors.New("volume is not attached")
+	ErrAttachLimitReached       = errors.New("max number of attachments per server reached")
+	ErrLockedServer             = errors.New("server is locked")
+	ErrVolumeSizeAlreadyReached = errors.New("volume size is already larger or equal than the requested size")
 )
 
 type Service interface {

--- a/volumes/service.go
+++ b/volumes/service.go
@@ -8,13 +8,14 @@ import (
 )
 
 var (
-	ErrVolumeNotFound      = errors.New("volume not found")
-	ErrVolumeAlreadyExists = errors.New("volume does already exist")
-	ErrServerNotFound      = errors.New("server not found")
-	ErrAttached            = errors.New("volume is attached")
-	ErrNotAttached         = errors.New("volume is not attached")
-	ErrAttachLimitReached  = errors.New("max number of attachments per server reached")
-	ErrLockedServer        = errors.New("server is locked")
+	ErrVolumeNotFound                       = errors.New("volume not found")
+	ErrVolumeAlreadyExists                  = errors.New("volume does already exist")
+	ErrServerNotFound                       = errors.New("server not found")
+	ErrAttached                             = errors.New("volume is attached")
+	ErrNotAttached                          = errors.New("volume is not attached")
+	ErrAttachLimitReached                   = errors.New("max number of attachments per server reached")
+	ErrLockedServer                         = errors.New("server is locked")
+	ErrVolumeAlreadyFulfillsSizeRequirement = errors.New("volume already has a size larger or equal than the request")
 )
 
 type Service interface {


### PR DESCRIPTION
If a previous resize attempt failed after calling `POST /v1/volumes/{id}/resize` (rate limit, network connectivity, ...), the volume might already have the target size.

The PVC (in Kubernetes) would still have the old size in its status, so the `external-resizer` makes another attempt at the resize. In the Hetzner Cloud API, a resize must always be larger than the current size, so the new resize failed with:

    volume size is too small (invalid_input)

This is now fixed, as we compare the size of the Hetzner Cloud volume to the desired size and only proceed if an actual resize is needed.

This was a violation of the CSI Spec[0], which stated for `ControllerExpandVolume`:

> This operation MUST be idempotent. If a volume corresponding to the specified volume ID is already larger than or equal to the target capacity of the expansion request, the plugin SHOULD reply 0 OK.

[0] https://github.com/container-storage-interface/spec/blob/release-1.9/spec.md#controllerexpandvolume