### PR TITLE
chore: fix missing `internal` path update

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,7 +8,7 @@
       "release-type": "go",
       "package-name": "csi-driver",
       "extra-files": [
-        "driver/driver.go",
+        "internal/driver/driver.go",
         "deploy/kubernetes/hcloud-csi.yml",
         "chart/.snapshots/default.yaml",
         "chart/.snapshots/example-prod.yaml",


### PR DESCRIPTION
Missing update that didn't make it in #626

