### PR TITLE
ci: cancel outdated kubernetes tests workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,9 @@ jobs:
     permissions:
       id-token: write
 
-    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k3s }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k3s }}
+      cancel-in-progress: true
 
     strategy:
       fail-fast: false # Continue tests matrix if a flaky run occur.


### PR DESCRIPTION
Cancel outdated Kubernetes tests workflows, as they take a long time and it does not make sens to wait for each run to complete.