### PR TITLE
feat(k8s): test against Kubernetes 1.30

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,14 @@ jobs:
       fail-fast: false # Continue tests matrix if a flaky run occur.
       matrix:
         include:
-          - k3s: v1.26
-            k8s-test: v1.26.15
           - k3s: v1.27
             k8s-test: v1.27.15
           - k3s: v1.28
             k8s-test: v1.28.11
           - k3s: v1.29
             k8s-test: v1.29.6
+          - k3s: v1.30
+            k8s-test: v1.30.2
 
     env:
       K3S_CHANNEL: ${{ matrix.k3s }}

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -207,10 +207,11 @@ Current Kubernetes Releases: https://kubernetes.io/releases/
 
 | Kubernetes | CSI Driver |                                                                                   Deployment File |
 |------------|-----------:|--------------------------------------------------------------------------------------------------:|
-| 1.29       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.28       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.27       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.26       |     2.6.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
+| 1.30       |     2.7.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.7.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.29       |     2.7.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.7.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.28       |     2.7.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.7.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.27       |     2.7.1+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.7.1/deploy/kubernetes/hcloud-csi.yml |
+| 1.26       |      2.7.1 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.7.1/deploy/kubernetes/hcloud-csi.yml |
 | 1.25       |      2.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.24       |      2.4.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.4.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.23       |      2.2.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.2.0/deploy/kubernetes/hcloud-csi.yml |

--- a/test/e2e/kubernetes/testdriver.yaml
+++ b/test/e2e/kubernetes/testdriver.yaml
@@ -10,7 +10,7 @@ DriverInfo:
     #
     # Available capabilities are defined in the kubernetes repositories, make
     # sure to select the corresponding k8s version:
-    # https://github.com/kubernetes/kubernetes/blob/release-1.26/test/e2e/storage/framework/testdriver.go#L150
+    # https://github.com/kubernetes/kubernetes/blob/release-1.27/test/e2e/storage/framework/testdriver.go#L150
     #
     # To get a list of new capabilities when upgrading, run this command in the kubernetes repository:
     #   git diff origin/release-1.26 origin/release-1.27 -- test/e2e/storage/framework/testdriver.go
@@ -31,6 +31,7 @@ DriverInfo:
     singleNodeVolume: true
     topology: true
     capacity: false
+    FSResizeFromSourceNotSupported: false
     readWriteOncePod: false # https://github.com/hetznercloud/csi-driver/issues/327
     multiplePVsSameID: true # No need to disable according to comment on CapMultiplePVsSameID
   SupportedFsType:


### PR DESCRIPTION
- Add tests for Kubernetes 1.30 and claim compatibility in docs.
- Drop tests for Kubernetes 1.26 to match our Kubernetes support policy (only active releases). 1.26 became EOL on 2024-02-28.


BEGIN_COMMIT_OVERRIDE
feat(k8s): test against Kubernetes 1.30
feat(k8s): drop Kubernetes 1.26 from tests
END_COMMIT_OVERRIDE