### PR TITLE
test: add integration test tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.txt ./...
+        run: go test -v -tags integration -race -coverprofile=coverage.txt ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To run the integrations tests, make sure you installed the following tools:
 1. Run the following command to run the integrations tests:
 
 ```sh
-go test -v ./test/integration
+go test -v -tags integration ./test/integration
 ```
 
 ### Run the kubernetes e2e tests

--- a/test/integration/cryptsetup_test.go
+++ b/test/integration/cryptsetup_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/test/integration/docker.go
+++ b/test/integration/docker.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -31,7 +31,7 @@ func prepareDockerImage() error {
 	defer os.Unsetenv("GOARCH")
 	os.Setenv("CGO_ENABLED", "0")
 	defer os.Unsetenv("CGO_ENABLED")
-	if output, err := runCmd("go", "test", "-c", "-o", "integration.tests"); err != nil {
+	if output, err := runCmd("go", "test", "-tags", "integration", "-c", "-o", "integration.tests"); err != nil {
 		return fmt.Errorf("error compiling test binary: %w\n%s", err, output)
 	}
 

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (


### PR DESCRIPTION
The integration test need docker to run, we use a tag to filter out integrations tests in environment that do not have docker.