### PR TITLE
 feat: truncate poll exponential backoff function to max 10s

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -149,7 +149,11 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger log.Logger)
 	}
 
 	opts = append(opts, hcloud.WithPollOpts(hcloud.PollOpts{
-		BackoffFunc: hcloud.ExponentialBackoff(2, time.Duration(pollingInterval)*time.Second),
+		BackoffFunc: hcloud.ExponentialBackoffWithOpts(hcloud.ExponentialBackoffOpts{
+			Base:       time.Duration(pollingInterval) * time.Second,
+			Multiplier: 2,
+			Cap:        5 * time.Second,
+		}),
 	}))
 
 	return hcloud.NewClient(opts...), nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -152,7 +152,7 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger log.Logger)
 		BackoffFunc: hcloud.ExponentialBackoffWithOpts(hcloud.ExponentialBackoffOpts{
 			Base:       time.Duration(pollingInterval) * time.Second,
 			Multiplier: 2,
-			Cap:        5 * time.Second,
+			Cap:        10 * time.Second,
 		}),
 	}))
 


### PR DESCRIPTION
Related to #346 and #380

The initial exponential back off algorithm introduced in #380 was not truncated, which could lead to very long intervals. The recent release of hcloud-go truncated the default exponential back off algorithm to 60s: https://github.com/hetznercloud/hcloud-go/commit/fd1f46cc35e61dde1e524399eef88c38a757636e

If we take the scenario described in #346, I think we can still reduce the max interval value for the exponential back off algorithm to <30s.