### PR TITLE
fix: xfs options compatibility between alpine and node kernel

### DIFF
--- a/internal/volumes/mount.go
+++ b/internal/volumes/mount.go
@@ -203,7 +203,10 @@ func (s *LinuxMountService) FormatDisk(disk string, fstype string) error {
 		_, _, err := command("mkfs.ext4", "-F", "-m0", disk)
 		return err
 	case "xfs":
-		_, _, err := command("mkfs.xfs", disk)
+		_, _, err := command(
+			"mkfs.xfs",
+			"-i", "nrext64=0", // Compatibility with kernel that do not support nrext64
+			disk)
 		return err
 	case "btrfs":
 		_, _, err := command("mkfs.btrfs", disk)


### PR DESCRIPTION
By default, the csi-driver formats the file system with the nrext64=1 flag.

But the mismatch between the supported XFS options between the csi-driver container (alpine 3.20) and the node kernel (5.15 on ubuntu 22.04) prevent the xfs filesystem to be mounted with:

```

Closes #648