### PR TITLE
feat: drop tests for Kubernetes 1.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,6 @@ jobs:
       fail-fast: false # Continue tests matrix if a flaky run occur.
       matrix:
         include:
-          - k3s: v1.27
-            k8s-test: v1.27.15
           - k3s: v1.28
             k8s-test: v1.28.13
           - k3s: v1.29

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -211,7 +211,7 @@ Current Kubernetes Releases: https://kubernetes.io/releases/
 | 1.30       |     2.9.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.9.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.29       |     2.9.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.9.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.28       |     2.9.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.9.0/deploy/kubernetes/hcloud-csi.yml |
-| 1.27       |     2.9.0+ | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.9.0/deploy/kubernetes/hcloud-csi.yml |
+| 1.27       |      2.9.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.9.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.26       |      2.7.1 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.7.1/deploy/kubernetes/hcloud-csi.yml |
 | 1.25       |      2.6.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.6.0/deploy/kubernetes/hcloud-csi.yml |
 | 1.24       |      2.4.0 | https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.4.0/deploy/kubernetes/hcloud-csi.yml |

--- a/test/e2e/kubernetes/testdriver.yaml
+++ b/test/e2e/kubernetes/testdriver.yaml
@@ -34,6 +34,7 @@ DriverInfo:
     FSResizeFromSourceNotSupported: false
     readWriteOncePod: false # https://github.com/hetznercloud/csi-driver/issues/327
     multiplePVsSameID: true # No need to disable according to comment on CapMultiplePVsSameID
+    capReadOnlyMany: false
   SupportedFsType:
     ext4:
     xfs:


### PR DESCRIPTION
Kubernetes v1.27 is End of Life since 2024-07-16. Removed from tests in accordance to our Kubernetes support policy (only active releases).

Also bumped to testdriver.yaml to specify capability that are available in 1.28+.