### PR TITLE
chore: Fix renovate for container tags in generated files

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,7 +61,7 @@ controller:
   image:
     csiAttacher:
       name: registry.k8s.io/sig-storage/csi-attacher
-      tag: v4.6.1 # renovate: datasource=github-releases depName=kubernetes-csi/external-attacher
+      tag: v4.6.1 # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-attacher
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -78,7 +78,7 @@ controller:
 
     csiResizer:
       name: registry.k8s.io/sig-storage/csi-resizer
-      tag: v1.11.2 # renovate: datasource=github-releases depName=kubernetes-csi/external-resizer
+      tag: v1.11.2 # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-resizer
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -95,7 +95,7 @@ controller:
 
     csiProvisioner:
       name: registry.k8s.io/sig-storage/csi-provisioner
-      tag: v5.0.2 # renovate: datasource=github-releases depName=kubernetes-csi/external-provisioner
+      tag: v5.0.2 # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-provisioner
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -112,7 +112,7 @@ controller:
 
     livenessProbe:
       name: registry.k8s.io/sig-storage/livenessprobe
-      tag: v2.13.1 # renovate: datasource=github-releases depName=kubernetes-csi/livenessprobe
+      tag: v2.13.1 # renovate: datasource=docker depName=registry.k8s.io/sig-storage/livenessprobe
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -397,7 +397,7 @@ node:
   image:
     csiNodeDriverRegistrar:
       name: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: v2.11.1 # renovate: datasource=github-releases depName=kubernetes-csi/node-driver-registrar
+      tag: v2.11.1 # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -414,7 +414,7 @@ node:
 
     livenessProbe:
       name: registry.k8s.io/sig-storage/livenessprobe
-      tag: v2.13.1 # renovate: datasource=github-releases depName=kubernetes-csi/livenessprobe
+      tag: v2.13.1 # renovate: datasource=docker depName=registry.k8s.io/sig-storage/livenessprobe
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,11 @@
         "github.com/kubernetes-csi/csi-test"
       ]
     }
-  ]
+  ],
+  "kubernetes": {
+    "fileMatch": [
+      "deploy/kubernetes/hcloud-csi.yml",
+      "chart/.snapshots/.+\\.yaml$"
+    ]
+  }
 }


### PR DESCRIPTION
- Autogenerated references are not updated by renovate
- Only open pull requests if container images are actually present