### PR TITLE
fix: updated capability response of the controller service

### DIFF
--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -331,6 +331,13 @@ func (s *ControllerService) ControllerGetCapabilities(context.Context, *proto.Co
 					},
 				},
 			},
+			{
+				Type: &proto.ControllerServiceCapability_Rpc{
+					Rpc: &proto.ControllerServiceCapability_RPC{
+						Type: proto.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+					},
+				},
+			},
 		},
 	}
 	return resp, nil

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -729,7 +729,7 @@ func TestControllerServiceControllerGetCapabilities(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(resp.Capabilities) != 4 {
+	if len(resp.Capabilities) != 5 {
 		t.Fatalf("unexpected number of capabilities: %d", len(resp.Capabilities))
 	}
 }


### PR DESCRIPTION
See #327 

SINGLE_NODE_MULTI_WRITER needs to be in the response of the ControllerGetCapabilities function to correctly integrate support for SINGLE_NODE_MULTI_WRITER access modes.

This was missing from #725.

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE