### PR TITLE
ci: build and test with Go 1.23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/publish_on_master.yml
+++ b/.github/workflows/publish_on_master.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - "v*.*.*"
+
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - name: Run tests
         run: go test -v -tags integration -race -coverprofile=coverage.txt ./...
@@ -50,7 +53,6 @@ jobs:
           - k3s: v1.31
             k8s-test: v1.30.1
 
-
     env:
       K3S_CHANNEL: ${{ matrix.k3s }}
       K8S_TEST_VERSION: ${{ matrix.k8s-test }}
@@ -61,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - uses: opentofu/setup-opentofu@v1
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ cache:
 
 build:
   stage: build
-  image: golang:1.22
+  image: golang:1.23
   script:
     - go env
     - go mod download
@@ -31,7 +31,7 @@ test:lint:
 
 test:unit:
   stage: test
-  image: golang:1.22
+  image: golang:1.23
   script:
     - go test -v -coverprofile=coverage.txt -covermode count ./...
     - go get github.com/boumenot/gocover-cobertura

--- a/deploy/docker-swarm/pkg/Dockerfile
+++ b/deploy/docker-swarm/pkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.22 as builder
+FROM --platform=$TARGETPLATFORM golang:1.23 as builder
 
 WORKDIR /build
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hetznercloud/csi-driver
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.23.2
 
 require (
 	github.com/container-storage-interface/spec v1.10.0


### PR DESCRIPTION
This PR makes the CI pipeline use Go 1.23 for building and testing.