### PR TITLE
feat(swarm): removed workaround support for mock staging/unstaging

### DIFF
--- a/deploy/docker-swarm/pkg/config.json
+++ b/deploy/docker-swarm/pkg/config.json
@@ -26,12 +26,6 @@
         "value"
       ],
       "value": "debug"
-    },
-    {
-      "name": "FORCE_STAGING_SUPPORT",
-      "description": "workaround: force staging support to make Docker 23.0.0 work without https://github.com/moby/swarmkit/pull/3116",
-      "settable": ["value"],
-      "value": "true"
     }
   ],
   "interface": {


### PR DESCRIPTION
With the merge of https://github.com/moby/swarmkit/pull/3116 the mock staging/unstaging is not needed anymore. It was introduced in our csi-driver in this commit: https://github.com/hetznercloud/csi-driver/commit/619fa5c3996e17e84b09deca0c956229e5554c77. Which is part of a large PR (squashed commit) that included experimental support for Docker swarm.

See:
- #376 
- #382 