### PR TITLE
fix: no longer logging sensitive mount options

### DIFF
--- a/internal/volumes/mount.go
+++ b/internal/volumes/mount.go
@@ -94,8 +94,6 @@ func (s *LinuxMountService) Publish(targetPath string, devicePath string, opts M
 		mountOptions = append(mountOptions, "ro")
 	}
 
-	mountOptions = append(mountOptions, opts.Additional...)
-
 	if opts.EncryptionPassphrase != "" {
 		existingFSType, err := s.mounter.GetDiskFormat(devicePath)
 		if err != nil {
@@ -131,10 +129,10 @@ func (s *LinuxMountService) Publish(targetPath string, devicePath string, opts M
 	)
 
 	if opts.BlockVolume {
-		return s.mounter.Mount(devicePath, targetPath, opts.FSType, mountOptions)
+		return s.mounter.MountSensitive(devicePath, targetPath, opts.FSType, mountOptions, opts.Additional)
 	}
 
-	return s.mounter.FormatAndMount(devicePath, targetPath, opts.FSType, mountOptions)
+	return s.mounter.FormatAndMountSensitive(devicePath, targetPath, opts.FSType, mountOptions, opts.Additional)
 }
 
 func (s *LinuxMountService) Unpublish(targetPath string) error {


### PR DESCRIPTION
We log the mount options with level info, which may contain sensitive information according to the [CSI-Spec](https://github.com/container-storage-interface/spec/blob/f6b6d53db606c651d975edf0ff3d0c9f5cd4fa35/spec.md?plain=1#L930).