### PR TITLE
feat: support for SELinux mount

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -360,5 +360,6 @@ spec:
   attachRequired: true
   fsGroupPolicy: File
   podInfoOnMount: true
+  seLinuxMount: true
   volumeLifecycleModes:
   - Persistent

--- a/chart/.snapshots/example-prod.yaml
+++ b/chart/.snapshots/example-prod.yaml
@@ -485,5 +485,6 @@ spec:
   attachRequired: true
   fsGroupPolicy: File
   podInfoOnMount: true
+  seLinuxMount: true
   volumeLifecycleModes:
   - Persistent

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -649,6 +649,7 @@ spec:
   attachRequired: true
   fsGroupPolicy: File
   podInfoOnMount: true
+  seLinuxMount: true
   volumeLifecycleModes:
   - Persistent
 ---

--- a/chart/templates/core/csidriver.yaml
+++ b/chart/templates/core/csidriver.yaml
@@ -6,5 +6,6 @@ spec:
   attachRequired: true
   fsGroupPolicy: File
   podInfoOnMount: true
+  seLinuxMount: true
   volumeLifecycleModes:
   - Persistent

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -397,5 +397,6 @@ spec:
   attachRequired: true
   fsGroupPolicy: File
   podInfoOnMount: true
+  seLinuxMount: true
   volumeLifecycleModes:
   - Persistent


### PR DESCRIPTION
Mount options specified in the NodePublishVolumeRequest are already forwarded to /bin/mount (`-o context=<SELinux_Label>`). The /bin/mount binary included in our container image can detect whether the kernel supports SELinux.

The user still has to enable the feature gates `SELinuxMount` and `SELinuxMountReadWriteOncePod` in Kubernetes version `1.30`.

Further Reference:
- [KEP 1710](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/1710-selinux-relabeling/README.md#volume-mounting)
- [What fields does the CSIDriver object have](https://kubernetes-csi.github.io/docs/csi-driver-object.html?highlight=SELinux#what-fields-does-the-csidriver-object-have)
- [Feature Gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features)

Closes #582