### PR TITLE
test: using wrong k8s-test version for 1.31

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,13 @@ jobs:
       matrix:
         include:
           - k3s: v1.28
-            k8s-test: v1.28.13
+            k8s-test: v1.28.14
           - k3s: v1.29
-            k8s-test: v1.29.8
+            k8s-test: v1.29.9
           - k3s: v1.30
-            k8s-test: v1.30.4
+            k8s-test: v1.30.5
           - k3s: v1.31
-            k8s-test: v1.30.1
+            k8s-test: v1.31.1
 
     env:
       K3S_CHANNEL: ${{ matrix.k3s }}


### PR DESCRIPTION
The 1.31 tests were using a test binary from 1.30.