### PR TITLE
deps: Replaced deprecated linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,8 +15,8 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - errcheck
-    - exportloopref
     - gci
     - gocritic
     - gofmt

--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -142,6 +142,10 @@ spec:
                 operator: NotIn
                 values:
                 - "true"
+              - key: instance.hetzner.cloud/provided-by
+                operator: In
+                values:
+                - cloud
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -143,9 +143,9 @@ spec:
                 values:
                 - "true"
               - key: instance.hetzner.cloud/provided-by
-                operator: In
+                operator: NotIn
                 values:
-                - cloud
+                - robot
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/chart/.snapshots/full.values.yaml
+++ b/chart/.snapshots/full.values.yaml
@@ -370,3 +370,4 @@ storageClasses:
   - name: foobar
     defaultStorageClass: false
     reclaimPolicy: Keep
+    allowedTopologyCloudServer: false

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -245,6 +245,10 @@ spec:
                 operator: NotIn
                 values:
                 - "true"
+              - key: instance.hetzner.cloud/provided-by
+                operator: In
+                values:
+                - cloud
       nodeSelector:
         foo: bar
       tolerations:

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -246,9 +246,9 @@ spec:
                 values:
                 - "true"
               - key: instance.hetzner.cloud/provided-by
-                operator: In
+                operator: NotIn
                 values:
-                - cloud
+                - robot
       nodeSelector:
         foo: bar
       tolerations:

--- a/chart/templates/core/storageclass.yaml
+++ b/chart/templates/core/storageclass.yaml
@@ -16,6 +16,10 @@ allowedTopologies:
   - key: instance.hetzner.cloud/is-root-server
     values:
     - "false"
+- matchLabelExpressions:
+  - key: instance.hetzner.cloud/provided-by
+    values:
+    - "cloud"
 {{- end }}
 ---
 {{- end }}

--- a/chart/templates/core/storageclass.yaml
+++ b/chart/templates/core/storageclass.yaml
@@ -10,6 +10,13 @@ provisioner: csi.hetzner.cloud
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 reclaimPolicy: {{ $val.reclaimPolicy | quote }}
+{{- if $val.includesRobotServers }}
+allowedTopologies:
+- matchLabelExpressions:
+  - key: instance.hetzner.cloud/is-root-server
+    values:
+    - "false"
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/chart/templates/core/storageclass.yaml
+++ b/chart/templates/core/storageclass.yaml
@@ -10,7 +10,7 @@ provisioner: csi.hetzner.cloud
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 reclaimPolicy: {{ $val.reclaimPolicy | quote }}
-{{- if $val.includesRobotServers }}
+{{- if $val.allowedTopologyCloudServer }}
 allowedTopologies:
 - matchLabelExpressions:
   - key: instance.hetzner.cloud/is-root-server

--- a/chart/templates/core/storageclass.yaml
+++ b/chart/templates/core/storageclass.yaml
@@ -13,10 +13,6 @@ reclaimPolicy: {{ $val.reclaimPolicy | quote }}
 {{- if $val.allowedTopologyCloudServer }}
 allowedTopologies:
 - matchLabelExpressions:
-  - key: instance.hetzner.cloud/is-root-server
-    values:
-    - "false"
-- matchLabelExpressions:
   - key: instance.hetzner.cloud/provided-by
     values:
     - "cloud"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -728,4 +728,5 @@ storageClasses:
   - name: hcloud-volumes
     defaultStorageClass: true
     reclaimPolicy: Delete
-    includesRobotServers: false 
+    ## @param storageClass.allowedTopologyCloudServer Prevents pods from being scheduled on nodes, specifically Robot servers, where Hetzner volumes are unavailable
+    allowedTopologyCloudServer: false 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -557,9 +557,9 @@ node:
                 values:
                   - "true"
               - key: "instance.hetzner.cloud/provided-by"
-                operator: In
+                operator: NotIn
                 values:
-                  - "cloud"
+                  - "robot"
 
   ## @param node.nodeSelector Node labels for node pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -724,3 +724,4 @@ storageClasses:
   - name: hcloud-volumes
     defaultStorageClass: true
     reclaimPolicy: Delete
+    includesRobotServers: false 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -556,6 +556,10 @@ node:
                 operator: NotIn
                 values:
                   - "true"
+              - key: "instance.hetzner.cloud/provided-by"
+                operator: In
+                values:
+                  - "cloud"
 
   ## @param node.nodeSelector Node labels for node pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -174,6 +174,10 @@ spec:
                 operator: NotIn
                 values:
                 - "true"
+              - key: instance.hetzner.cloud/provided-by
+                operator: In
+                values:
+                - cloud
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -175,9 +175,9 @@ spec:
                 values:
                 - "true"
               - key: instance.hetzner.cloud/provided-by
-                operator: In
+                operator: NotIn
                 values:
-                - cloud
+                - robot
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -211,17 +211,17 @@ $ kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.
 
 Root servers can be part of the cluster, but the CSI plugin doesn't work there and the current behaviour of the scheduler can cause Pods to be stuck in `Pending`. 
 
-Include topology key evaluation into storage class, by setting the helm chart value `includesRobotServers`:
+Setting `allowedTopologyCloudServer` to true prevents pods from being scheduled on nodes, specifically Robot servers, where Hetzner volumes are unavailable. This value can not be changed after the initial creation of a storage class.
 
 ```yaml
 storageClasses:
   - name: hcloud-volumes
     defaultStorageClass: true
     reclaimPolicy: Delete
-    includesRobotServers: true # <---
+    allowedTopologyCloudServer: true # <---
 ```
 
-Label the nodes according to their type:
+To ensure proper topology evaluation, labels are needed to indicate whether a node is a cloud VM or a dedicated server from Robot. If you are using the `hcloud-cloud-controller-manager` version 1.20.0 or later, these labels are added automatically. Otherwise, you will need to label the nodes manually.
 
 ### New Label
 

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -223,6 +223,21 @@ storageClasses:
 
 Label the nodes according to their type:
 
+### New Label
+
+**Cloud Servers**
+```bash
+kubectl label nodes <node name> instance.hetzner.cloud/provided-by=cloud
+```
+
+**Root Servers**
+```bash
+kubectl label nodes <node name> instance.hetzner.cloud/provided-by=robot
+```
+
+
+### Old Label
+
 **Cloud Servers**
 ```bash
 kubectl label nodes <node name> instance.hetzner.cloud/is-root-server=false

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -209,8 +209,26 @@ $ kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.
 
 ## Integration with Root Servers
 
-Root servers can be part of the cluster, but the CSI plugin doesn't work there. Taint the root server as follows to skip that node for the DaemonSet.
+Root servers can be part of the cluster, but the CSI plugin doesn't work there and the current behaviour of the scheduler can cause Pods to be stuck in `Pending`. 
 
+Include topology key evaluation into storage class, by setting the helm chart value `includesRobotServers`:
+
+```yaml
+storageClasses:
+  - name: hcloud-volumes
+    defaultStorageClass: true
+    reclaimPolicy: Delete
+    includesRobotServers: true # <---
+```
+
+Label the nodes according to their type:
+
+**Cloud Servers**
+```bash
+kubectl label nodes <node name> instance.hetzner.cloud/is-root-server=false
+```
+
+**Root Servers**
 ```bash
 kubectl label nodes <node name> instance.hetzner.cloud/is-root-server=true
 ```

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -236,7 +236,9 @@ kubectl label nodes <node name> instance.hetzner.cloud/provided-by=robot
 ```
 
 
-### Old Label
+### DEPRECATED: Old Label
+
+Please switch to the [new label](#new-label). The label `instance.hetzner.cloud/is-robot-server` will be removed in future releases.
 
 **Cloud Servers**
 ```bash

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -10,4 +10,5 @@ const (
 
 	TopologySegmentLocation = PluginName + "/location"
 	IsRootServerLabel       = "instance.hetzner.cloud/is-root-server"
+	ProvidedByLabel         = "instance.hetzner.cloud/provided-by"
 )

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -9,6 +9,5 @@ const (
 	DefaultVolumeSize = MinVolumeSize
 
 	TopologySegmentLocation = PluginName + "/location"
-	IsRootServerLabel       = "instance.hetzner.cloud/is-root-server"
 	ProvidedByLabel         = "instance.hetzner.cloud/provided-by"
 )

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -9,4 +9,5 @@ const (
 	DefaultVolumeSize = MinVolumeSize
 
 	TopologySegmentLocation = PluginName + "/location"
+	IsRootServerLabel       = "instance.hetzner.cloud/is-root-server"
 )

--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -178,7 +178,6 @@ func (s *NodeService) NodeGetInfo(_ context.Context, _ *proto.NodeGetInfoRequest
 		AccessibleTopology: &proto.Topology{
 			Segments: map[string]string{
 				TopologySegmentLocation: s.serverLocation,
-				IsRootServerLabel:       "false",
 				ProvidedByLabel:         "cloud",
 			},
 		},

--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -178,6 +178,7 @@ func (s *NodeService) NodeGetInfo(_ context.Context, _ *proto.NodeGetInfoRequest
 		AccessibleTopology: &proto.Topology{
 			Segments: map[string]string{
 				TopologySegmentLocation: s.serverLocation,
+				IsRootServerLabel:       "false",
 			},
 		},
 	}

--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -179,6 +179,7 @@ func (s *NodeService) NodeGetInfo(_ context.Context, _ *proto.NodeGetInfoRequest
 			Segments: map[string]string{
 				TopologySegmentLocation: s.serverLocation,
 				IsRootServerLabel:       "false",
+				ProvidedByLabel:         "cloud",
 			},
 		},
 	}


### PR DESCRIPTION
exportloopref is no longer relevant since Go v1.22 and got replaced with copyloopvar. This causes a warning during lint runs.