### PR TITLE
chore: replaced deprecated linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,8 +15,8 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - errcheck
-    - exportloopref
     - gci
     - gocritic
     - gofmt


### PR DESCRIPTION
The exportloopref linter got deprecated and is no longer relevant since Go v1.22. It got replaced with the copyloopvar linter. Updated our golangci configuration.