### PR TITLE
ci: fixed verify snapshots using wrong path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Verify Snapshots
         run: |
           hack/update-helm-snapshots.sh
-          git diff --exit-code -- deploy/
+          git diff --exit-code -- chart/.snapshots/
 
       - name: Show warning
         if: failure()


### PR DESCRIPTION
In our verify snapshots step, the git diff command is targeting the deploy/ directory instead of chart/.snapshots/.