### PR TITLE
refactor: redefintion and shadowing of builtin id cap

### DIFF
--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -49,8 +49,8 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 	}
 
 	// Check if ALL volume capabilities are supported.
-	for i, cap := range req.VolumeCapabilities {
-		if !isCapabilitySupported(cap) {
+	for i, capability := range req.VolumeCapabilities {
+		if !isCapabilitySupported(capability) {
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("capability at index %d is not supported", i))
 		}
 	}
@@ -255,8 +255,8 @@ func (s *ControllerService) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 
 	confirmed := true
-	for _, cap := range req.VolumeCapabilities {
-		if !isCapabilitySupported(cap) {
+	for _, capability := range req.VolumeCapabilities {
+		if !isCapabilitySupported(capability) {
 			confirmed = false
 			break
 		}

--- a/internal/driver/helper.go
+++ b/internal/driver/helper.go
@@ -45,11 +45,11 @@ func volumeSizeFromCapacityRange(cr *proto.CapacityRange) (int, int, bool) {
 	return minSize, maxSize, true
 }
 
-func isCapabilitySupported(cap *proto.VolumeCapability) bool {
-	if cap.AccessMode == nil {
+func isCapabilitySupported(capability *proto.VolumeCapability) bool {
+	if capability.AccessMode == nil {
 		return false
 	}
-	switch cap.AccessMode.Mode {
+	switch capability.AccessMode.Mode {
 	case proto.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:
 		return true
 	case proto.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:


### PR DESCRIPTION
Update PR of golangci-lint to v1.62.0 discovered a redefinition of cap in our capability check. Furthermore, we are shadowing cap in certain places.

Additionally, upgrade from v1.62.0 of golangci-lint (#774) can not be merged before this is fixed.