### PR TITLE
fix: prefer scheduling the csi controller on cloud nodes

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -263,6 +263,16 @@ spec:
     spec:
       serviceAccountName: hcloud-csi-controller
       
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: instance.hetzner.cloud/provided-by
+                operator: In
+                values:
+                - cloud
+            weight: 1
       securityContext:
         fsGroup: 1001
       initContainers:

--- a/chart/.snapshots/example-prod.yaml
+++ b/chart/.snapshots/example-prod.yaml
@@ -341,6 +341,15 @@ spec:
       serviceAccountName: hcloud-csi-controller
       
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: instance.hetzner.cloud/provided-by
+                operator: In
+                values:
+                - cloud
+            weight: 1
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -299,8 +299,19 @@ controller:
 
   ## @param controller.affinity Affinity for controller pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## If not otherwise configured, we retrieve the default location for volumes by the location of the node where the controller is scheduled.
+  ## For this reason we preferably want to schedule the controller on a cloud node.
   ##
-  affinity: {}
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "instance.hetzner.cloud/provided-by"
+                operator: In
+                values:
+                  - "cloud"
 
   ## @param controller.nodeSelector Node labels for controller pods assignment
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -296,6 +296,16 @@ spec:
     spec:
       serviceAccountName: hcloud-csi-controller
       
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: instance.hetzner.cloud/provided-by
+                operator: In
+                values:
+                - cloud
+            weight: 1
       securityContext:
         fsGroup: 1001
       initContainers:


### PR DESCRIPTION
This is only a partial fix, but in clusters where the `instance.hetzner.cloud/provided-by` label is present and set accordingly for cloud nodes it prevents the controller from being scheduled on non cloud nodes. We need this, as in our default behavior for fetching the default volume location we rely on the node name being a Hetzner cloud.