### PR TITLE
perf: reduced number of requests needed for fetching default volume location

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,7 +42,7 @@ func main() {
 		}
 
 		location, err = app.GetServerLocation(logger, hcloudClient, metadataClient)
-		if err != nil || location == "" {
+		if err != nil {
 			logger.Error(
 				"failed to fetch server",
 				"err", err,
@@ -55,6 +55,11 @@ func main() {
 		"evaluated default location for volumes",
 		"location", location,
 	)
+
+	if location == "" {
+		logger.Error("could not set a default location for volumes")
+		os.Exit(1)
+	}
 
 	enableProvidedByTopology := app.GetEnableProvidedByTopology()
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -30,7 +30,6 @@ func main() {
 	}
 
 	var location string
-
 	if s := os.Getenv("HCLOUD_VOLUME_DEFAULT_LOCATION"); s != "" {
 		location = s
 	} else {
@@ -42,17 +41,20 @@ func main() {
 				"You can set HCLOUD_VOLUME_DEFAULT_LOCATION if you want to run it somewhere else.")
 		}
 
-		server, err := app.GetServer(logger, hcloudClient, metadataClient)
-		if err != nil {
+		location, err = app.GetServerLocation(logger, hcloudClient, metadataClient)
+		if err != nil || location == "" {
 			logger.Error(
 				"failed to fetch server",
 				"err", err,
 			)
 			os.Exit(1)
 		}
-
-		location = server.Datacenter.Location.Name
 	}
+
+	logger.Debug(
+		"evaluated default location for volumes",
+		"location", location,
+	)
 
 	enableProvidedByTopology := app.GetEnableProvidedByTopology()
 

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -145,7 +145,7 @@ If you set any options at all, it is your responsible to make sure that all defa
 
 ### Volume Location
 
-During the CSI controller's initialization, the default location for all volumes is determined through the following prioritized methods (in order of evaluation from 1 to 4):
+During the initialization of the CSI controller, the default location for all volumes is determined based on the following prioritized methods (evaluated in order from 1 to 4). However, when `volumeBindingMode: WaitForFirstConsumer` is used, the volume's location is determined by the node where the Pod is scheduled, and the default location is not applicable. For more details, refer to the official [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
 
 1. The location is explicitly set using the `HCLOUD_VOLUME_DEFAULT_LOCATION` variable.
 2. The location is derived by querying a server specified by the `HCLOUD_SERVER_ID` variable.

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -143,6 +143,15 @@ When using XFS as the filesystem type and no `fsFormatOptions` are set, we apply
 
 If you set any options at all, it is your responsible to make sure that all default flags from `mkfs.xfs` are supported on your current Linux Kernel version or that you set the flags appropriately.
 
+### Volume Location
+
+During the CSI controller's initialization, the default location for all volumes is determined through the following prioritized methods (in order of evaluation from 1 to 4):
+
+1. The location is explicitly set using the `HCLOUD_VOLUME_DEFAULT_LOCATION` variable.
+2. The location is derived by querying a server specified by the `HCLOUD_SERVER_ID` variable.
+3. If neither of the above is set, the `KUBE_NODE_NAME` environment variable defaults to the name of the node where the CSI controller is scheduled. This node name is then used to query the Hetzner API for a matching server and its location.
+4. As a final fallback, the [Hetzner metadata service](https://docs.hetzner.cloud/#server-metadata) is queried to obtain the server ID, which is then used to fetch the location from the Hetzner API.
+
 ## Upgrading
 
 To upgrade the csi-driver version, you just need to apply the new manifests to your cluster.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -200,7 +200,7 @@ func getLocationByEnvID(logger *slog.Logger, hcloudClient *hcloud.Client) (bool,
 
 	id, err := strconv.ParseInt(envID, 10, 64)
 	if err != nil {
-		return true, "", fmt.Errorf("invalid server id in HCLOUD_SERVER_ID env var: %s", err)
+		return true, "", fmt.Errorf("invalid server id in HCLOUD_SERVER_ID env var: %s", envID)
 	}
 
 	logger.Debug(

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -167,69 +167,97 @@ func CreateHcloudClient(metricsRegistry *prometheus.Registry, logger *slog.Logge
 	return hcloud.NewClient(opts...), nil
 }
 
-// GetServer retrieves the hcloud server the application is running on.
-func GetServer(logger *slog.Logger, hcloudClient *hcloud.Client, metadataClient *metadata.Client) (*hcloud.Server, error) {
-	hcloudServerID, err := getServerID(logger, hcloudClient, metadataClient)
+// GetServerLocation retrieves the hcloud server the application is running on.
+func GetServerLocation(logger *slog.Logger, hcloudClient *hcloud.Client, metadataClient *metadata.Client) (string, error) {
+	// Option 1: Get from HCLOUD_SERVER_ID env
+	// This env would be set explicitly by the user
+	// If this is set and location can not be found we do not want a fallback
+	isSet, location, err := getLocationByEnvID(logger, hcloudClient)
+	if isSet {
+		return location, err
+	}
+
+	// Option 2: Get from node name and search server list
+	// This env is set by default via a fieldRef on spec.nodeName
+	// If this is set and server can not be found we fallback to the metadata fallback
+	location, err = getLocationByEnvNodeName(logger, hcloudClient)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	logger.Debug("fetching server")
-	server, _, err := hcloudClient.Server.GetByID(context.Background(), hcloudServerID)
-	if err != nil {
-		return nil, err
+	if location != "" {
+		return location, nil
 	}
 
-	// Cover potential cases where the server is not found. This results in a
-	// nil server object and nil error. If we do not do this, we will panic
-	// when trying to log the server.Name.
-	if server == nil {
-		return nil, errors.New("could not determine server")
-	}
-
-	logger.Info("fetched server", "server-name", server.Name)
-
-	return server, nil
+	// Option 3: Metadata service as fallback
+	return getLocationFromMetadata(logger, metadataClient)
 }
 
-func getServerID(logger *slog.Logger, hcloudClient *hcloud.Client, metadataClient *metadata.Client) (int64, error) {
-	if s := os.Getenv("HCLOUD_SERVER_ID"); s != "" {
-		id, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid server id in HCLOUD_SERVER_ID env var: %s", err)
-		}
-		logger.Debug(
-			"using server id from HCLOUD_SERVER_ID env var",
-			"server-id", id,
-		)
-		return id, nil
+func getLocationByEnvID(logger *slog.Logger, hcloudClient *hcloud.Client) (bool, string, error) {
+	envID := os.Getenv("HCLOUD_SERVER_ID")
+	if envID == "" {
+		return false, "", nil
 	}
 
-	if s := os.Getenv("KUBE_NODE_NAME"); s != "" {
-		server, _, err := hcloudClient.Server.GetByName(context.Background(), s)
-		if err != nil {
-			return 0, fmt.Errorf("error while getting server through node name: %s", err)
-		}
-		if server != nil {
-			logger.Debug(
-				"using server name from KUBE_NODE_NAME env var",
-				"server-id", server.ID,
-			)
-			return server.ID, nil
-		}
-		logger.Debug(
-			"server not found by name, fallback to metadata service",
-			"err", err,
-		)
+	id, err := strconv.ParseInt(envID, 10, 64)
+	if err != nil {
+		return true, "", fmt.Errorf("invalid server id in HCLOUD_SERVER_ID env var: %s", err)
 	}
 
 	logger.Debug(
-		"getting instance id from metadata service",
+		"using server id from HCLOUD_SERVER_ID env var",
+		"server-id", id,
 	)
-	id, err := metadataClient.InstanceID()
+
+	server, _, err := hcloudClient.Server.GetByID(context.Background(), id)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get instance id from metadata service: %s", err)
+		return true, "", err
 	}
-	return id, nil
+	if server == nil {
+		return true, "", fmt.Errorf("HCLOUD_SERVER_ID is set to %d, but no server could be found", id)
+	}
+
+	return true, server.Datacenter.Location.Name, nil
+}
+
+func getLocationByEnvNodeName(logger *slog.Logger, hcloudClient *hcloud.Client) (string, error) {
+	nodeName := os.Getenv("KUBE_NODE_NAME")
+	if nodeName == "" {
+		return "", nil
+	}
+
+	server, _, err := hcloudClient.Server.GetByName(context.Background(), nodeName)
+	if err != nil {
+		return "", fmt.Errorf("error while getting server through node name: %s", err)
+	}
+	if server != nil {
+		logger.Debug(
+			"fetched server via server name from KUBE_NODE_NAME env var",
+			"server-id", server.ID,
+		)
+		return server.Datacenter.Location.Name, nil
+	}
+
+	logger.Info(
+		"KUBE_NODE_NAME is set, but no server could be found",
+		"KUBE_NODE_NAME", nodeName,
+	)
+
+	return "", nil
+}
+
+func getLocationFromMetadata(logger *slog.Logger, metadataClient *metadata.Client) (string, error) {
+	logger.Debug("getting location from metadata service")
+	availabilityZone, err := metadataClient.AvailabilityZone()
+	if err != nil {
+		return "", fmt.Errorf("failed to get location from metadata service: %s", err)
+	}
+
+	parts := strings.Split(availabilityZone, "-")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("availability zone from metadata service is not in the correct format, got: %s", availabilityZone)
+	}
+
+	return parts[0], nil
 }
 
 func CreateGRPCServer(logger *slog.Logger, metricsInterceptor grpc.UnaryServerInterceptor) *grpc.Server {


### PR DESCRIPTION
In our default strategy to fetch the default volume location there was an additional unnecessary request to the Hetzner API.

When fetching the location via the metadata service, we can directly utilize the availability zone provided by the service instead of using the server id to fetch the location and therefore making an additional request.