### PR TITLE
ci: export k8s logs and events from csi-driver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,31 @@ jobs:
           source dev/files/env.sh
           make -C test/e2e/kubernetes serial
 
+      - name: Dump logs & events
+        if: always()
+        continue-on-error: true
+        run: |
+          source dev/files/env.sh
+          mkdir debug-logs
+
+          echo "::group::hcloud-csi.log"
+          kubectl logs \
+            --namespace kube-system \
+            --selector app.kubernetes.io/name=hcloud-csi \
+            --all-containers \
+            --prefix=true \
+            --tail=-1 \
+            | tee debug-logs/hcloud-csi.log
+          echo "::endgroup::"
+
+          echo "::group::events.yaml"
+          kubectl get events \
+            --all-namespaces \
+            --sort-by=.firstTimestamp \
+            --output yaml \
+            | tee debug-logs/events.yaml
+          echo "::endgroup::"
+
       - name: Cleanup
         if: always()
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,14 @@ jobs:
         continue-on-error: true
         run: make -C dev down
 
+      - name: Persist debug artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-logs-k8s-${{ env.ENV }}
+          path: debug-logs/
+
   nomad:
     name: nomad ${{ matrix.nomad }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,7 @@ jobs:
     env:
       TF_VAR_nomad_version: ${{ matrix.nomad }}
       TF_VAR_consul_version: ${{ matrix.consul }}
+      ENV: gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.nomad }}
 
     steps:
       - uses: actions/checkout@v4
@@ -218,7 +219,56 @@ jobs:
           source nomad/dev/files/env.sh
           go test -v -tags e2e ./test/e2e/nomad/...
 
+      - name: Dump logs & events
+        if: always()
+        continue-on-error: true
+        run: |
+          source dev/files/env.sh
+          mkdir debug-logs
+
+          fetch_logs_from_job () {
+            ALLOC_IDS=$(nomad job allocs -json "$1" | jq -r ".[].ID")
+
+            for ALLOC_ID in $ALLOC_IDS; do
+                echo "::group::hcloud-csi.log::$1::$ALLOC_ID"
+                nomad alloc logs "$ALLOC_ID"
+                echo "::endgroup::"
+            done
+          }
+
+          fetch_events_from_job () {
+            ALLOC_IDS=$(nomad job allocs -json "$1" | jq -r ".[].ID")
+
+            for ALLOC_ID in $ALLOC_IDS; do
+                echo "::group::events.json::$1::$ALLOC_ID"
+                nomad alloc status -json $ALLOC_ID | jq -r ".TaskStates.plugin.Events"
+                echo "::endgroup::"
+            done
+          }
+
+          {
+              echo "::group::hcloud-csi.log"
+              fetch_logs_from_job hcloud-csi-controller
+              fetch_logs_from_job hcloud-csi-node
+              echo "::endgroup::"
+          } | tee debug-logs/hcloud-csi.log
+
+          {
+              echo "::group::events.json"
+              fetch_events_from_job hcloud-csi-controller
+              fetch_events_from_job hcloud-csi-node
+              echo "::endgroup::"
+          } | tee debug-logs/events.json
+
       - name: Cleanup
         if: always()
         continue-on-error: true
         run: make -C nomad/dev down
+
+      - name: Persist debug artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-logs-nomad-${{ env.ENV }}
+          path: debug-logs/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,17 +247,13 @@ jobs:
           }
 
           {
-              echo "::group::hcloud-csi.log"
               fetch_logs_from_job hcloud-csi-controller
               fetch_logs_from_job hcloud-csi-node
-              echo "::endgroup::"
           } | tee debug-logs/hcloud-csi.log
 
           {
-              echo "::group::events.json"
               fetch_events_from_job hcloud-csi-controller
               fetch_events_from_job hcloud-csi-node
-              echo "::endgroup::"
           } | tee debug-logs/events.json
 
       - name: Cleanup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
         continue-on-error: true
         run: |
           source dev/files/env.sh
-          mkdir debug-logs
+          mkdir -p debug-logs
 
           echo "::group::hcloud-csi.log"
           kubectl logs \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          source dev/files/env.sh
+          source nomad/dev/files/env.sh
           mkdir debug-logs
 
           fetch_logs_from_job () {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,7 +224,7 @@ jobs:
         continue-on-error: true
         run: |
           source nomad/dev/files/env.sh
-          mkdir debug-logs
+          mkdir -p debug-logs
 
           fetch_logs_from_job () {
             ALLOC_IDS=$(nomad job allocs -json "$1" | jq -r ".[].ID")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,19 +230,21 @@ jobs:
             # Fetch all allocations from a job
             ALLOC_IDS=$(nomad job allocs -json "$1" | jq -r ".[].ID")
 
-            # Fetch logs of all allocations and append it to the logs file
+            # Fetch logs of each allocation and dump them in a file
             for ALLOC_ID in $ALLOC_IDS; do
                 echo "::group::hcloud-csi.log::$1::$ALLOC_ID"
-                nomad alloc logs "$ALLOC_ID"
+                nomad alloc logs "$ALLOC_ID" | tee "debug-logs/$1-$ALLOC_ID.log"
                 echo "::endgroup::"
-            done | tee -a debug-logs/hcloud-csi.log
+            done
 
-            # Fetch events of all allocations and append it to the events file
+            # Fetch events of each allocation and dump them in a file
             for ALLOC_ID in $ALLOC_IDS; do
                 echo "::group::events.json::$1::$ALLOC_ID"
-                nomad alloc status -json $ALLOC_ID | jq -r ".TaskStates.plugin.Events"
+                nomad alloc status -json $ALLOC_ID \
+                  | jq -r ".TaskStates.plugin.Events" \
+                  | tee "debug-logs/$1-$ALLOC_ID.json"
                 echo "::endgroup::"
-            done | tee -a debug-logs/events.json
+            done
           }
 
           fetch_job_info hcloud-csi-controller

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,35 +226,27 @@ jobs:
           source nomad/dev/files/env.sh
           mkdir -p debug-logs
 
-          fetch_logs_from_job () {
+          fetch_job_info () {
+            # Fetch all allocations from a job
             ALLOC_IDS=$(nomad job allocs -json "$1" | jq -r ".[].ID")
 
+            # Fetch logs of all allocations and append it to the logs file
             for ALLOC_ID in $ALLOC_IDS; do
                 echo "::group::hcloud-csi.log::$1::$ALLOC_ID"
                 nomad alloc logs "$ALLOC_ID"
                 echo "::endgroup::"
-            done
-          }
+            done | tee -a debug-logs/hcloud-csi.log
 
-          fetch_events_from_job () {
-            ALLOC_IDS=$(nomad job allocs -json "$1" | jq -r ".[].ID")
-
+            # Fetch events of all allocations and append it to the events file
             for ALLOC_ID in $ALLOC_IDS; do
                 echo "::group::events.json::$1::$ALLOC_ID"
                 nomad alloc status -json $ALLOC_ID | jq -r ".TaskStates.plugin.Events"
                 echo "::endgroup::"
-            done
+            done | tee -a debug-logs/events.json
           }
 
-          {
-              fetch_logs_from_job hcloud-csi-controller
-              fetch_logs_from_job hcloud-csi-node
-          } | tee debug-logs/hcloud-csi.log
-
-          {
-              fetch_events_from_job hcloud-csi-controller
-              fetch_events_from_job hcloud-csi-node
-          } | tee debug-logs/events.json
+          fetch_job_info hcloud-csi-controller
+          fetch_job_info hcloud-csi-node
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Adds scripts to our CI to capture the logs and events in Kubernetes and Nomad. These are exported as artifacts with the naming `debug-logs-k8s-XXX` and `debug-logs-nomad-XXX` where `XXX` is information about the current environment.