### PR TITLE
ci: update nomad api weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
         "github.com/container-storage-interface/spec",
         "github.com/kubernetes-csi/csi-test"
       ]
+    },
+    {
+      "description": "search for nomad api updates on every Sunday",
+      "matchPackageNames": ["github.com/hashicorp/nomad/api"],
+      "schedule": ["* * * * 0"]
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
Schedule github.com/hashicorp/nomad/api to be updated on every Sunday of the week. As github.com/hashicorp/nomad/api is not properly versioned we receive a new PR (or PR update) for every new git commit on the main branch.