### PR TITLE
feat: support ReadWriteOncePod

### DIFF
--- a/internal/driver/helper.go
+++ b/internal/driver/helper.go
@@ -54,6 +54,8 @@ func isCapabilitySupported(capability *proto.VolumeCapability) bool {
 		return true
 	case proto.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
 		return true
+	case proto.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER:
+		return true
 	default:
 		return false
 	}

--- a/test/e2e/kubernetes/testdriver.yaml
+++ b/test/e2e/kubernetes/testdriver.yaml
@@ -32,7 +32,7 @@ DriverInfo:
     topology: true
     capacity: false
     FSResizeFromSourceNotSupported: false
-    readWriteOncePod: false # https://github.com/hetznercloud/csi-driver/issues/327
+    readWriteOncePod: true # https://github.com/hetznercloud/csi-driver/issues/327
     multiplePVsSameID: true # No need to disable according to comment on CapMultiplePVsSameID
     capReadOnlyMany: false
   SupportedFsType:


### PR DESCRIPTION
According to [KEP-2485](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/README.md#csi-specification-changes-volume-capabilities), if the csi-driver exposes the `SINGLE_NODE_MULTI_WRITER` capability, then `ReadWriteOncePod` will map to the `SINGLE_NODE_SINGLE_WRITER` volume capability, otherwise it will map to `SINGLE_NODE_WRITER`. Our controller already responded with the `SINGLE_NODE_MULTI_WRITER`, but we blocked `SINGLE_NODE_SINGLE_WRITER` in a validation step in the `ControllerPublishVolume` method.

Additional reference:
- https://kubernetes.io/blog/2021/09/13/read-write-once-pod-access-mode-alpha/#accept-new-csi-access-modes
- #327 