### PR TITLE
docs: Highlight Kubernetes Docs More Clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ Orchestrators. Please note that this driver **requires Kubernetes 1.19 or newer*
 
 ## Getting Started
 
-Depending on your Container Orchestrator you need to follow different steps to
-get started with the Hetzner Cloud csi-driver. You can also find other docs
-relevant to that Container Orchestrator behind the link:
+- [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md#getting-started)
 
-- [Kubernetes](./docs/kubernetes/README.md#getting-started)
-- [Docker Swarm](./docs/docker-swarm/README.md)️ _⚠️ Not officially supported_
-- [HashiCorp Nomad](./docs/nomad/README.md)️ _⚠️ Not officially supported_
+## Not officially supported environments
+
+- [Docker Swarm](./docs/docker-swarm/README.md)️
+- [HashiCorp Nomad](./docs/nomad/README.md)️
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Orchestrators. Please note that this driver **requires Kubernetes 1.19 or newer*
 
 ## Getting Started
 
-- [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md#getting-started)
+Depending on your Container Orchestrator you need to follow different steps to
+get started with the Hetzner Cloud csi-driver. You can also find other docs
+relevant to that Container Orchestrator behind these links.
+
+- [Kubernetes](./docs/kubernetes/README.md#getting-started)
 
 #### Environments Outside Official Support
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Orchestrators. Please note that this driver **requires Kubernetes 1.19 or newer*
 
 - [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md#getting-started)
 
-## Not officially supported environments
+#### Environments Outside Official Support
 
 - [Docker Swarm](./docs/docker-swarm/README.md)️
 - [HashiCorp Nomad](./docs/nomad/README.md)️

--- a/docs/docker-swarm/README.md
+++ b/docs/docker-swarm/README.md
@@ -2,7 +2,7 @@
 
 ⚠️ Docker Swarm is not officially supported.
 
- Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is officially supported.
+Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is officially supported.
 
 ---
 

--- a/docs/docker-swarm/README.md
+++ b/docs/docker-swarm/README.md
@@ -1,9 +1,15 @@
 # Docker Swarm Hetzner Cloud CSI plugin
 
-Currently in Beta. Please consult the Docker Swarm documentation
-for cluster volumes (=CSI) support at https://github.com/moby/moby/blob/master/docs/cluster_volumes.md
+⚠️ Docker Swarm is not officially supported.
 
-The community is tracking the state of support for CSI in Docker Swarm over at https://github.com/olljanat/csi-plugins-for-docker-swarm
+ Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is officially supported.
+
+---
+
+Currently in Beta. Please consult the Docker Swarm documentation
+for cluster volumes (=CSI) support at <https://github.com/moby/moby/blob/master/docs/cluster_volumes.md>
+
+The community is tracking the state of support for CSI in Docker Swarm over at <https://github.com/olljanat/csi-plugins-for-docker-swarm>
 
 ## How to install the plugin
 

--- a/docs/docker-swarm/README.md
+++ b/docs/docker-swarm/README.md
@@ -7,9 +7,9 @@ Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is offic
 ---
 
 Currently in Beta. Please consult the Docker Swarm documentation
-for cluster volumes (=CSI) support at <https://github.com/moby/moby/blob/master/docs/cluster_volumes.md>
+for cluster volumes (=CSI) support at https://github.com/moby/moby/blob/master/docs/cluster_volumes.md
 
-The community is tracking the state of support for CSI in Docker Swarm over at <https://github.com/olljanat/csi-plugins-for-docker-swarm>
+The community is tracking the state of support for CSI in Docker Swarm over at https://github.com/olljanat/csi-plugins-for-docker-swarm
 
 ## How to install the plugin
 

--- a/docs/docker-swarm/README.md
+++ b/docs/docker-swarm/README.md
@@ -2,7 +2,7 @@
 
 ⚠️ Docker Swarm is not officially supported.
 
-Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is officially supported.
+Only [Kubernetes](./docs/kubernetes/README.md) is officially supported.
 
 ---
 

--- a/docs/nomad/README.md
+++ b/docs/nomad/README.md
@@ -2,7 +2,7 @@
 
 ⚠️ Nomad is not officially supported.
 
-Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is officially supported.
+Only [Kubernetes](./docs/kubernetes/README.md) is officially supported.
 
 ## Preconditions
 

--- a/docs/nomad/README.md
+++ b/docs/nomad/README.md
@@ -1,5 +1,9 @@
 # HashiCorp Nomad Hetzner Cloud csi-driver
 
+⚠️ Nomad is not officially supported.
+
+Only [Kubernetes Hetzner Cloud csi-driver](./docs/kubernetes/README.md) is officially supported.
+
 ## Preconditions
 
 - Nomad >= 1.4.x cluster installed following the [Nomad Reference Architecture for production deployments](https://developer.hashicorp.com/nomad/tutorials/enterprise/production-reference-architecture-vm-with-consul). The setup was tested on Nomad Community, version 1.9.3.


### PR DESCRIPTION
Closes #941 

This PR moves the unsupported lines (Docker Swarm, Nomand) to the buttom, so that the supported docs are more visible.

Result looks like this now: https://github.com/guettli/csi-driver/tree/tg/highlight-kubernetes-docs-more-clearly?tab=readme-ov-file#getting-started