### PR TITLE
ci(e2e): less ginkgo output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,10 @@ jobs:
       K8S_TEST_VERSION: ${{ matrix.k8s-test }}
       ENV: gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.k3s }}
 
+      # These ginkgo flags were only added in 2.17+2.18, which is available in Kubernetes v1.31+
+      # Can be simplified once we no longer test <1.31.
+      GINKGO_EXTRA_ARGS: ${{ (matrix.k3s != 'v1.29' && matrix.k3s != 'v1.30') && '--silence-skips --github-output' || '' }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/test/e2e/kubernetes/Makefile
+++ b/test/e2e/kubernetes/Makefile
@@ -4,6 +4,7 @@ K8S_TEST_VERSION ?= v1.32.1
 
 GINKGO = bin/ginkgo
 GINKGO_ARGS = -v --flake-attempts=2
+GINKGO_EXTRA_ARGS ?= ""
 
 E2E = bin/e2e.test
 E2E_ARGS = -storage.testdriver=$(CURDIR)/testdriver.yaml
@@ -16,14 +17,14 @@ bin:
 			kubernetes/test/bin/ginkgo
 
 parallel: bin
-	$(GINKGO) $(GINKGO_ARGS) \
+	$(GINKGO) $(GINKGO_ARGS) $(GINKGO_EXTRA_ARGS) \
 		-nodes=12 \
 		-focus='External.Storage' \
 		-skip='\[Feature:|\[Disruptive\]|\[Serial\]' \
 		$(E2E) -- $(E2E_ARGS)
 
 serial: bin
-	$(GINKGO) $(GINKGO_ARGS) \
+	$(GINKGO) $(GINKGO_ARGS) $(GINKGO_EXTRA_ARGS) \
 		-focus='External.Storage.*(\[Feature:|\[Serial\])' \
 		$(E2E) -- $(E2E_ARGS)
 


### PR DESCRIPTION
The `e2e.test` binary has __all__ kubernetes tests, but we only run those that start with `External.Storage`. This means there is a lot of "Skipped" output right now, that is useless. By setting `--silence-skips` these log lines are removed.

Additional ginkgo offers a `--github-output` flag that promises to make the output nicer for GitHub actions. Not sure what it really does.

These flags are only supported in Ginkgo 2.18+, which is only available in Kubernetes 1.31+.