### PR TITLE
fix(helm): node extraVolumeMounts are added to wrong container

### DIFF
--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -278,8 +278,6 @@ spec:
               mountPath: /run/csi
             - name: registration-dir
               mountPath: /registration
-            - mountPath: /tmp/extra-volume
-              name: extra-volume
           resources:
             limits:
               cpu: 51m
@@ -312,6 +310,8 @@ spec:
               mountPath: /run/csi
             - name: device-dir
               mountPath: /dev
+            - mountPath: /tmp/extra-volume
+              name: extra-volume
           securityContext:
             privileged: true
           env:

--- a/chart/templates/node/daemonset.yaml
+++ b/chart/templates/node/daemonset.yaml
@@ -83,9 +83,6 @@ spec:
               mountPath: /run/csi
             - name: registration-dir
               mountPath: /registration
-            {{- if .Values.node.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.node.extraVolumeMounts "context" $) | nindent 12 }}
-            {{- end }}
           {{- if .Values.node.resources.csiNodeDriverRegistrar }}
           resources: {{- toYaml .Values.node.resources.csiNodeDriverRegistrar | nindent 12 }}
           {{- end }}
@@ -110,6 +107,9 @@ spec:
               mountPath: /run/csi
             - name: device-dir
               mountPath: /dev
+            {{- if .Values.node.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.node.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
The value `node.extraVolumeMounts` should add those mounts to the `hcloud-csi-driver` container according to the docs. They were instead added to the `csi-node-driver-registrar` container.