### PR TITLE
ci: evaluate coverage of e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,31 @@ jobs:
           source dev/files/env.sh
           make -C test/e2e/kubernetes serial
 
+      - name: Get code coverage
+        run: |
+          source dev/files/env.sh
+          bash hack/get-coverage-from-k8s.sh
+
+      - name: Upload controller coverage reports to Codecov
+        if: >
+          !startsWith(github.head_ref, 'renovate/') &&
+          !startsWith(github.head_ref, 'releaser-pleaser--')
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/controller/coverage.txt
+          flags: e2e-controller
+
+      - name: Upload node coverage reports to Codecov
+        if: >
+          !startsWith(github.head_ref, 'renovate/') &&
+          !startsWith(github.head_ref, 'releaser-pleaser--')
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/node/coverage.txt
+          flags: e2e-node
+
       - name: Dump logs & events
         if: always()
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ hcloud-csi-*.tgz
 
 # Test binary for integration tests
 test/integration/integration.tests
+
+coverage/

--- a/cmd/aio/main.go
+++ b/cmd/aio/main.go
@@ -21,6 +21,7 @@ var logger *slog.Logger
 
 func main() {
 	logger = app.CreateLogger()
+	app.SetupCoverageSignalHandler(logger)
 
 	m := app.CreateMetrics(logger)
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ var logger *slog.Logger
 
 func main() {
 	logger = app.CreateLogger()
+	app.SetupCoverageSignalHandler(logger)
 
 	m := app.CreateMetrics(logger)
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -19,6 +19,7 @@ var logger *slog.Logger
 
 func main() {
 	logger = app.CreateLogger()
+	app.SetupCoverageSignalHandler(logger)
 
 	m := app.CreateMetrics(logger)
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,9 +13,10 @@ ARG GOARCH=amd64
 ARG CGO_ENABLED=0
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
+ARG GO_BUILDFLAGS
 
-RUN go build -gcflags="$SKAFFOLD_GO_GCFLAGS" -o controller.bin github.com/hetznercloud/csi-driver/cmd/controller
-RUN go build -gcflags="$SKAFFOLD_GO_GCFLAGS" -o node.bin github.com/hetznercloud/csi-driver/cmd/node
+RUN go build -gcflags="$SKAFFOLD_GO_GCFLAGS" $GO_BUILDFLAGS -o controller.bin github.com/hetznercloud/csi-driver/cmd/controller
+RUN go build -gcflags="$SKAFFOLD_GO_GCFLAGS" $GO_BUILDFLAGS -o node.bin github.com/hetznercloud/csi-driver/cmd/node
 
 FROM alpine:3.21
 

--- a/hack/get-coverage-from-k8s.sh
+++ b/hack/get-coverage-from-k8s.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -ueo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"  &> /dev/null && pwd)"
+COVERDIR="$SCRIPT_DIR/../coverage"
+COVERDIR_CONTROLLER="$COVERDIR/controller"
+COVERDIR_NODE="$COVERDIR/node"
+
+# Create/clean coverage directory
+if [ -d "$COVERDIR" ]; then
+  echo "$COVERDIR already exists; cleaning"
+  rm -r "$COVERDIR"
+fi
+mkdir "$COVERDIR"
+
+signal_coverage_write() {
+  mkdir "$1"
+  for i in "${@:2}"; do
+    echo "Sending USR1 signal to $i"
+    kubectl -n kube-system exec -t "$i" -c hcloud-csi-driver -- kill -USR1 1
+    sleep 0.5
+    echo "Pulling coverage from $i into $1"
+    kubectl cp -n kube-system -c hcloud-csi-driver "$i:/coverage" "$1"
+  done
+
+  go tool covdata textfmt -i "$1" -o "$1/coverage.txt"
+}
+
+CONTROLLER_PODS=$(
+  kubectl -n kube-system get pods \
+    --no-headers -o custom-columns=":metadata.name" \
+    -l app.kubernetes.io/instance=hcloud-csi \
+    -l app.kubernetes.io/component=controller
+)
+NODE_PODS=$(
+  kubectl -n kube-system get pods \
+    --no-headers -o custom-columns=":metadata.name" \
+    -l app.kubernetes.io/instance=hcloud-csi \
+    -l app.kubernetes.io/component=node
+)
+
+# shellcheck disable=SC2086
+signal_coverage_write "$COVERDIR_CONTROLLER" $CONTROLLER_PODS
+# shellcheck disable=SC2086
+signal_coverage_write "$COVERDIR_NODE" $NODE_PODS

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,6 +7,8 @@ build:
     - image: docker.io/hetznercloud/hcloud-csi-driver
       docker:
         dockerfile: dev/Dockerfile
+        buildArgs:
+          GO_BUILDFLAGS: -covermode=atomic -coverpkg=github.com/hetznercloud/csi-driver/...
   local:
     useBuildkit: true
   insecureRegistries:
@@ -18,3 +20,17 @@ deploy:
       - name: hcloud-csi
         namespace: kube-system
         chartPath: chart
+        setValues:
+          controller.extraEnvVars[0].name: GOCOVERDIR
+          controller.extraEnvVars[0].value: "/coverage"
+          controller.extraVolumes[0].name: coverage
+          controller.extraVolumes[0].emptyDir: {}
+          controller.extraVolumeMounts[0].name: coverage
+          controller.extraVolumeMounts[0].mountPath: "/coverage"
+
+          node.extraEnvVars[0].name: GOCOVERDIR
+          node.extraEnvVars[0].value: "/coverage"
+          node.extraVolumes[0].name: coverage
+          node.extraVolumes[0].emptyDir: {}
+          node.extraVolumeMounts[0].name: coverage
+          node.extraVolumeMounts[0].mountPath: "/coverage"


### PR DESCRIPTION
In the dev env we now always include coverage in the built binaries.

We can send a `USR1` signal to the process to write it to a directory in the pod.

A script iterates over all pods, sends the signal and then pulls the coverage.

We combine the coverage for all node pods.