### PR TITLE
feat: rename default labels on Volumes

### DIFF
--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -24,9 +24,9 @@ const (
 	parameterKeyPVName       = "csi.storage.k8s.io/pv/name"
 	parameterKeyLabels       = "labels"
 
-	labelKeyPVCName      = "pvc-name"
-	labelKeyPVCNamespace = "pvc-namespace"
-	labelKeyPVName       = "pv-name"
+	labelKeyPVCName      = "csi.storage.k8s.io/pvc-name"
+	labelKeyPVCNamespace = "csi.storage.k8s.io/pvc-namespace"
+	labelKeyPVName       = "csi.storage.k8s.io/pv-name"
 	labelKeyManagedBy    = "managed-by"
 )
 

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -24,9 +24,9 @@ const (
 	parameterKeyPVName       = "csi.storage.k8s.io/pv/name"
 	parameterKeyLabels       = "labels"
 
-	labelKeyPVCName      = "csi.storage.k8s.io/pvc-name"
-	labelKeyPVCNamespace = "csi.storage.k8s.io/pvc-namespace"
-	labelKeyPVName       = "csi.storage.k8s.io/pv-name"
+	labelKeyPVCName      = "pvc-name"
+	labelKeyPVCNamespace = "pvc-namespace"
+	labelKeyPVName       = "pv-name"
 	labelKeyManagedBy    = "managed-by"
 )
 

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -19,15 +19,11 @@ import (
 )
 
 const (
-	parameterKeyPVCName      = "csi.storage.k8s.io/pvc/name"
-	parameterKeyPVCNamespace = "csi.storage.k8s.io/pvc/namespace"
-	parameterKeyPVName       = "csi.storage.k8s.io/pv/name"
-	parameterKeyLabels       = "labels"
-
-	tagKeyCreatedForClaimName      = "csi.storage.k8s.io/pvc/name"
-	tagKeyCreatedForClaimNamespace = "csi.storage.k8s.io/pvc/namespace"
-	tagKeyCreatedForVolumeName     = "csi.storage.k8s.io/pv/name"
-	tagKeyCreatedBy                = "csi.hetzner.cloud/created-by"
+	KeyPVCName      = "csi.storage.k8s.io/pvc/name"
+	KeyPVCNamespace = "csi.storage.k8s.io/pvc/namespace"
+	KeyPVName       = "csi.storage.k8s.io/pv/name"
+	KeyLabels       = "labels"
+	KeyManagedBy    = "managed-by"
 )
 
 type ControllerService struct {
@@ -85,20 +81,20 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 	}
 
 	var volumeLabels = map[string]string{
-		tagKeyCreatedBy: "csi-driver",
+		KeyManagedBy: fmt.Sprintf("csi-driver-%s", PluginVersion),
 	}
 
 	maps.Copy(volumeLabels, s.extraVolumeLabels)
 
 	for key, value := range req.GetParameters() {
 		switch strings.ToLower(key) {
-		case parameterKeyPVCName:
-			volumeLabels[tagKeyCreatedForClaimName] = value
-		case parameterKeyPVCNamespace:
-			volumeLabels[tagKeyCreatedForClaimNamespace] = value
-		case parameterKeyPVName:
-			volumeLabels[tagKeyCreatedForVolumeName] = value
-		case parameterKeyLabels:
+		case KeyPVCName:
+			volumeLabels[KeyPVCName] = value
+		case KeyPVCNamespace:
+			volumeLabels[KeyPVCNamespace] = value
+		case KeyPVName:
+			volumeLabels[KeyPVName] = value
+		case KeyLabels:
 			customLabels, err := utils.ConvertLabelsToMap(value)
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "Invalid format of parameter labels: %s", err)

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -81,7 +81,7 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 	}
 
 	var volumeLabels = map[string]string{
-		KeyManagedBy: fmt.Sprintf("csi-driver-%s", PluginVersion),
+		KeyManagedBy: "csi-driver",
 	}
 
 	maps.Copy(volumeLabels, s.extraVolumeLabels)

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -19,11 +19,15 @@ import (
 )
 
 const (
-	KeyPVCName      = "csi.storage.k8s.io/pvc/name"
-	KeyPVCNamespace = "csi.storage.k8s.io/pvc/namespace"
-	KeyPVName       = "csi.storage.k8s.io/pv/name"
-	KeyLabels       = "labels"
-	KeyManagedBy    = "managed-by"
+	parameterKeyPVCName      = "csi.storage.k8s.io/pvc/name"
+	parameterKeyPVCNamespace = "csi.storage.k8s.io/pvc/namespace"
+	parameterKeyPVName       = "csi.storage.k8s.io/pv/name"
+	parameterKeyLabels       = "labels"
+
+	labelKeyPVCName      = "pvc-name"
+	labelKeyPVCNamespace = "pvc-namespace"
+	labelKeyPVName       = "pv-name"
+	labelKeyManagedBy    = "managed-by"
 )
 
 type ControllerService struct {
@@ -81,20 +85,20 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 	}
 
 	var volumeLabels = map[string]string{
-		KeyManagedBy: "csi-driver",
+		labelKeyManagedBy: "csi-driver",
 	}
 
 	maps.Copy(volumeLabels, s.extraVolumeLabels)
 
 	for key, value := range req.GetParameters() {
 		switch strings.ToLower(key) {
-		case KeyPVCName:
-			volumeLabels[KeyPVCName] = value
-		case KeyPVCNamespace:
-			volumeLabels[KeyPVCNamespace] = value
-		case KeyPVName:
-			volumeLabels[KeyPVName] = value
-		case KeyLabels:
+		case parameterKeyPVCName:
+			volumeLabels[labelKeyPVCName] = value
+		case parameterKeyPVCNamespace:
+			volumeLabels[labelKeyPVCNamespace] = value
+		case parameterKeyPVName:
+			volumeLabels[labelKeyPVName] = value
+		case parameterKeyLabels:
 			customLabels, err := utils.ConvertLabelsToMap(value)
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "Invalid format of parameter labels: %s", err)

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -61,13 +61,13 @@ func TestControllerServiceCreateVolume(t *testing.T) {
 		if v, ok := opts.Labels["clusterName"]; !ok || v != "myCluster" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
-		if v, ok := opts.Labels[KeyPVCName]; !ok || v != "pvc-name" {
+		if v, ok := opts.Labels[labelKeyPVCName]; !ok || v != "pvc-name" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
-		if v, ok := opts.Labels[KeyPVCNamespace]; !ok || v != "default" {
+		if v, ok := opts.Labels[labelKeyPVCNamespace]; !ok || v != "default" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
-		if v, ok := opts.Labels[KeyPVName]; !ok || v != "pv-name" {
+		if v, ok := opts.Labels[labelKeyPVName]; !ok || v != "pv-name" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
 		return &csi.Volume{
@@ -85,9 +85,9 @@ func TestControllerServiceCreateVolume(t *testing.T) {
 			LimitBytes:    2 * MinVolumeSize * GB,
 		},
 		Parameters: map[string]string{
-			KeyPVCName:      "pvc-name",
-			KeyPVCNamespace: "default",
-			KeyPVName:       "pv-name",
+			parameterKeyPVCName:      "pvc-name",
+			parameterKeyPVCNamespace: "default",
+			parameterKeyPVName:       "pv-name",
 		},
 		VolumeCapabilities: []*proto.VolumeCapability{
 			{

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -61,13 +61,13 @@ func TestControllerServiceCreateVolume(t *testing.T) {
 		if v, ok := opts.Labels["clusterName"]; !ok || v != "myCluster" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
-		if v, ok := opts.Labels[tagKeyCreatedForClaimName]; !ok || v != "pvc-name" {
+		if v, ok := opts.Labels[KeyPVCName]; !ok || v != "pvc-name" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
-		if v, ok := opts.Labels[tagKeyCreatedForClaimNamespace]; !ok || v != "default" {
+		if v, ok := opts.Labels[KeyPVCNamespace]; !ok || v != "default" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
-		if v, ok := opts.Labels[tagKeyCreatedForVolumeName]; !ok || v != "pv-name" {
+		if v, ok := opts.Labels[KeyPVName]; !ok || v != "pv-name" {
 			t.Errorf("unexpected labels passed to volume service: %s", opts.Labels)
 		}
 		return &csi.Volume{
@@ -85,9 +85,9 @@ func TestControllerServiceCreateVolume(t *testing.T) {
 			LimitBytes:    2 * MinVolumeSize * GB,
 		},
 		Parameters: map[string]string{
-			parameterKeyPVCName:      "pvc-name",
-			parameterKeyPVCNamespace: "default",
-			parameterKeyPVName:       "pv-name",
+			KeyPVCName:      "pvc-name",
+			KeyPVCNamespace: "default",
+			KeyPVName:       "pv-name",
 		},
 		VolumeCapabilities: []*proto.VolumeCapability{
 			{


### PR DESCRIPTION
After implementing the new label we have discovered an inconsistency in the Hetzner Cloud public API. The topic was discussed internally and as a result we have to remove the `csi.hetzner.cloud` prefix from the label. Besides, we have decided to rename the label to `managed-by`, as this is more consistent with other integrations (e.g., fleeting-plugin-hetzner). 

Additionally, the Kubernetes labels (e.g., `csi.storage.k8s.io/pvc/name`) are not valid, as there is a second `slash` in the key.