### PR TITLE
ci: remove explicit go version from setup-go

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  GOTOOLCHAIN: local
-
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_on_master.yml
+++ b/.github/workflows/publish_on_master.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
 
-env:
-  GOTOOLCHAIN: local
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -4,9 +4,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  GOTOOLCHAIN: local
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  GOTOOLCHAIN: local
-
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
setup-go v6.0.0 now respects the go toolchain directive. We can now remove the workaround of specifying the go version explicitly in the setup-go action.