### PR TITLE
ci: add go version file to setup-go

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/publish_on_master.yml
+++ b/.github/workflows/publish_on_master.yml
@@ -13,6 +13,8 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -13,6 +13,8 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: Run tests
         run: go test -v -tags integration -race -coverprofile=coverage.txt ./...
@@ -61,6 +63,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - uses: opentofu/setup-opentofu@v1
         with:
@@ -204,6 +208,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - uses: opentofu/setup-opentofu@v1
         with:


### PR DESCRIPTION
In #1076, we should have switched back to `go-version-file`. Since we want to extract the Go version from the toolchain directive in `go.mod`, we should follow the [docs](https://github.com/actions/setup-go/tree/v6.0.0?tab=readme-ov-file&utm_source=chatgpt.com#getting-go-version-from-the-gomod-file). The documentation is not very clear about the default behavior when using only `uses: actions/setup-go@v6`, so it seems safer to explicitly specify `go-version-file`.