### PR TITLE
feat(helm): support NetworkPolicy

### DIFF
--- a/chart/templates/controller/networkpolicy.yaml
+++ b/chart/templates/controller/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.controller.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "common.names.fullname" . }}-controller
+  namespace: {{ include "common.names.namespace" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- if .Values.controller.matchLabelsOverride }}
+      {{- toYaml .Values.controller.matchLabelsOverride | nindent 6 }}
+      {{- else }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+      {{- end }}
+  policyTypes:
+  - Ingress
+  - Egress
+  {{- with .Values.controller.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.controller.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 2 }}
+  {{- else }}
+  egress:
+  - {} # Allow all egress traffic by default
+  {{- end }}
+{{- end }}

--- a/chart/templates/node/networkpolicy.yaml
+++ b/chart/templates/node/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.node.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "common.names.fullname" . }}-node
+  namespace: {{ include "common.names.namespace" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- if .Values.node.matchLabelsOverride }}
+      {{- toYaml .Values.node.matchLabelsOverride | nindent 6 }}
+      {{- else }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: node
+      {{- end }}
+  policyTypes:
+  - Ingress
+  - Egress
+  {{- with .Values.node.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.node.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 2 }}
+  {{- else }}
+  egress:
+  - {} # Allow all egress traffic by default
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -398,6 +398,24 @@ controller:
   ##
   initContainers: []
 
+  ## @param controller.networkPolicy.enabled Enable NetworkPolicy for controller pods
+  networkPolicy:
+    ## @param controller.networkPolicy.enabled Enable NetworkPolicy for controller pods
+    ##
+    enabled: false
+    ## @param controller.networkPolicy.ingress Ingress rules for controller pods
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
+    ##
+    ingress:
+      # Health
+      - ports:
+        - port: 9808
+          protocol: TCP
+    ## @param controller.networkPolicy.egress Egress rules for controller pods
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
+    ##
+    egress: {}
+
 ## @section Node Parameters
 ##
 
@@ -672,6 +690,33 @@ node:
   ## kubeletDir: /var/snap/microk8s/common/var/lib/kubelet
   ##
   kubeletDir: /var/lib/kubelet
+
+  ## @param node.networkPolicy.enabled Enable NetworkPolicy for node pods
+  networkPolicy:
+    ## @param node.networkPolicy.enabled Enable NetworkPolicy for node pods
+    ##
+    enabled: false
+    ## @param node.networkPolicy.ingress Ingress rules for node pods
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
+    ##
+    ingress:
+      # Health
+      - ports:
+        - port: 9808
+          protocol: TCP
+    ## @param node.networkPolicy.egress Egress rules for node pods
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
+    ##
+    egress:
+      # Hetzner Cloud Metadata
+      - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        ports:
+          - port: 80
+            protocol: TCP
+          - port: 443
+            protocol: TCP
 
 ## @section Other Parameters
 ##


### PR DESCRIPTION
Add support for NetworkPolicy creation. Default to disabled.

This would be useful for cluster which do deny ingress or egress by default.