### PR TITLE
refactor: fix armv6 build error on volume stats

### DIFF
--- a/internal/volumes/stats.go
+++ b/internal/volumes/stats.go
@@ -33,6 +33,8 @@ func (l *LinuxStatsService) ByteFilesystemStats(volumePath string) (totalBytes i
 		return
 	}
 
+	// golang.org/x/sys/unix returns a 32-bit integer on 32-bit systems (ARMv6)
+	// ensure it is converted to int64
 	bsize := int64(statfs.Bsize)
 
 	bavail, err := utils.UInt64ToInt64(statfs.Bavail)


### PR DESCRIPTION
dace8da did not build successfully on ARMv6 (32-bit), as `golang.org/x/sys/unix` returns a 32-bit integer on 32-bit systems. I don't think this needs to be a `fix:` as we did not release this yet.

- [`Statfs_t` on amd64](https://cs.opensource.google/go/x/sys/+/refs/tags/v0.36.0:unix/ztypes_linux_amd64.go;l=460)
- [`Statfs_t` on arm](https://cs.opensource.google/go/x/sys/+/refs/tags/v0.36.0:unix/ztypes_linux_arm.go;l=438)