### PR TITLE
fix: strip leading non-alphanumeric characters after truncating volume label

### DIFF
--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -117,6 +117,12 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 		// Truncate label values to fit API requirements
 		if len(v) > MaxLabelValueLength {
 			truncated := v[len(v)-MaxLabelValueLength:]
+			// After truncation the first character might not be alphanumeric
+			// (e.g. a dash), which violates the label spec. Strip any
+			// leading non-alphanumeric characters.
+			truncated = strings.TrimLeftFunc(truncated, func(r rune) bool {
+				return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+			})
 			s.logger.Warn(
 				"volume label value truncated",
 				"volume", req.GetName(),

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -200,6 +200,52 @@ func TestControllerServiceCreateVolumeWithParameterLabels(t *testing.T) {
 	}
 }
 
+func TestControllerServiceCreateVolumeWithTruncatedLabelStartingWithDash(t *testing.T) {
+	env := newControllerServiceTestEnv()
+
+	env.service.enableProvidedByTopology = true
+
+	env.volumeService.CreateFunc = func(ctx context.Context, opts volumes.CreateOpts) (*csi.Volume, error) {
+		// Input: "a" + 63x"-" + "b" (65 chars). After truncating to last 63: 62x"-" + "b".
+		// After stripping leading non-alphanumeric chars: "b".
+		if v, ok := opts.Labels["test"]; !ok || v != "b" {
+			t.Errorf("unexpected label value after truncation: %q", v)
+		}
+		return &csi.Volume{
+			ID:       1,
+			Name:     opts.Name,
+			Size:     opts.MinSize,
+			Location: opts.Location,
+		}, nil
+	}
+
+	req := &proto.CreateVolumeRequest{
+		Name: "testvol",
+		CapacityRange: &proto.CapacityRange{
+			RequiredBytes: MinVolumeSize*GB + 100,
+			LimitBytes:    2 * MinVolumeSize * GB,
+		},
+		Parameters: map[string]string{"labels": "test=a---------------------------------------------------------------b"},
+		VolumeCapabilities: []*proto.VolumeCapability{
+			{
+				AccessType: &proto.VolumeCapability_Mount{
+					Mount: &proto.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &proto.VolumeCapability_AccessMode{
+					Mode: proto.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	resp, err := env.service.CreateVolume(env.ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.GetVolume().GetVolumeId() != "1" {
+		t.Errorf("unexpected value for VolumeId: %s", resp.GetVolume().GetVolumeId())
+	}
+}
+
 func TestControllerServiceCreateVolumeWithLocation(t *testing.T) {
 	env := newControllerServiceTestEnv()
 


### PR DESCRIPTION
The label value truncation introduced in v2.20.1 could produce values starting with a non-alphanumeric character (e.g. -), which is invalid per the https://docs.hetzner.cloud/reference/cloud#description/labels. Truncated values are now stripped of leading non-alphanumeric characters to ensure they remain valid.