### PR TITLE
fix: auto-detach volume from previous server before attaching to new one

### DIFF
--- a/internal/volsrv/volume.go
+++ b/internal/volsrv/volume.go
@@ -222,12 +222,43 @@ func (s *VolumeService) Attach(ctx context.Context, volume *csi.Volume, server *
 			)
 			return nil
 		}
+
 		s.logger.Info(
-			"volume is already attached to another server",
+			"volume is attached to another server, detaching first",
 			"volume-id", volume.ID,
-			"server-id", hcloudVolume.Server.ID,
+			"from-server-id", hcloudVolume.Server.ID,
+			"to-server-id", server.ID,
 		)
-		return volumes.ErrAttached
+
+		detachAction, _, err := s.client.Volume.Detach(ctx, hcloudVolume)
+		if err != nil {
+			s.logger.Info(
+				"failed to detach volume from previous server",
+				"volume-id", volume.ID,
+				"server-id", hcloudVolume.Server.ID,
+				"err", errutil.LogValue(err),
+			)
+			if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+				return volumes.ErrLockedServer
+			}
+			return err
+		}
+		if err := s.client.Action.WaitFor(ctx, detachAction); err != nil {
+			s.logger.Info(
+				"failed to detach volume from previous server",
+				"volume-id", volume.ID,
+				"server-id", hcloudVolume.Server.ID,
+				"err", errutil.LogValue(err),
+			)
+			return err
+		}
+
+		s.logger.Info(
+			"volume detached from previous server, proceeding with attach",
+			"volume-id", volume.ID,
+			"from-server-id", hcloudVolume.Server.ID,
+			"to-server-id", server.ID,
+		)
 	}
 
 	action, _, err := s.client.Volume.Attach(ctx, hcloudVolume, hcloudServer)


### PR DESCRIPTION
## Summary

When a volume is already attached to server A and Kubernetes schedules the pod to server B (e.g. after node reboot or failure), the CSI driver now automatically detaches the volume from server A before attaching it to server B.

Previously, this scenario returned `ErrAttached` ("volume is attached") without attempting to migrate the volume, leaving pods stuck in `ContainerCreating` indefinitely.

## Problem

After a node reboot or failure, Kubernetes reschedules pods to healthy nodes. The CSI driver's `Attach` function checks if the volume is already attached to another server and returns an error immediately, without attempting to detach first. This breaks the standard CSI volume lifecycle where volumes should follow pods across nodes.

Reported in #1155 — exact error:
```
rpc error: code = FailedPrecondition desc = failed to publish volume: volume is attached
```

## Fix

In `internal/volsrv/volume.go` `Attach()`:
- When volume is attached to the **same server** → return nil (unchanged, idempotent)
- When volume is attached to a **different server** → detach from old server first, then proceed with attach to new server

## Testing

- Verified the fix compiles against the changed package
- The change follows the existing detach pattern already used in `Detach()`
- Error handling covers locked server and action wait failures

Fixes #1155