### PR TITLE
fix(helm): drop unused secrets get/list permission from controller

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -56,9 +56,6 @@ rules:
     verbs: [patch]
   # provisioner
   - apiGroups: [""]
-    resources: [secrets]
-    verbs: [get, list]
-  - apiGroups: [""]
     resources: [persistentvolumes]
     verbs: [get, list, watch, create, delete, patch]
   - apiGroups: [""]

--- a/chart/.snapshots/example-prod.yaml
+++ b/chart/.snapshots/example-prod.yaml
@@ -79,9 +79,6 @@ rules:
     verbs: [patch]
   # provisioner
   - apiGroups: [""]
-    resources: [secrets]
-    verbs: [get, list]
-  - apiGroups: [""]
     resources: [persistentvolumes]
     verbs: [get, list, watch, create, delete, patch]
   - apiGroups: [""]

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -89,9 +89,6 @@ rules:
     verbs: [patch]
   # provisioner
   - apiGroups: [""]
-    resources: [secrets]
-    verbs: [get, list]
-  - apiGroups: [""]
     resources: [persistentvolumes]
     verbs: [get, list, watch, create, delete, patch]
   - apiGroups: [""]

--- a/chart/templates/controller/clusterrole.yaml
+++ b/chart/templates/controller/clusterrole.yaml
@@ -41,9 +41,6 @@ rules:
     verbs: [patch]
   # provisioner
   - apiGroups: [""]
-    resources: [secrets]
-    verbs: [get, list]
-  - apiGroups: [""]
     resources: [persistentvolumes]
     verbs: [get, list, watch, create, delete, patch]
   - apiGroups: [""]

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -54,9 +54,6 @@ rules:
     verbs: [patch]
   # provisioner
   - apiGroups: [""]
-    resources: [secrets]
-    verbs: [get, list]
-  - apiGroups: [""]
     resources: [persistentvolumes]
     verbs: [get, list, watch, create, delete, patch]
   - apiGroups: [""]


### PR DESCRIPTION
The `hcloud-csi-driver` does not handle the common secrets `csi.storage.k8s.io/provisioner-secret-name` or `csi.storage.k8s.io/controller-publish-secret-name` (+ `-namespace` secrets). Instead, it is configured globally with one API token. This token is mounted as an environment variable and therefore, does not require us to read secrets via the Kubernetes API.

The secrets used for Volume encryption are fetched by kubelet.

See https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#storageclass-secrets

Fixes #1417

~~~rp-commits
fix(helm): drop unused secrets get/list permission from controller
~~~
