### PR TITLE
ci: fix lychee failing on release pr ci

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -19,6 +19,8 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
+      # On the releaser-pleaser PR the new release tag does not exist yet, so its
+      # release URL is excluded below to avoid a false-positive 404.
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           fail: true
@@ -29,6 +31,7 @@ jobs:
             --cache
             --max-cache-age 2d
             --include-fragments
+            ${{ github.head_ref == 'releaser-pleaser--branches--main' && '--exclude https://github.com/hetznercloud/csi-driver/releases/tag/' || '' }}
             --exclude 'api.hetzner.cloud'
             --exclude 'api.hetzner.com'
             --exclude 'https://docs.hetzner.cloud/reference/cloud#'


### PR DESCRIPTION
On release PRs lychee fails because the new tag mentioned in the CHANGELOG.md does not yet exist.

With this fix we still have link checking for tags on all other branches and our release notes
are still checked for broken links.
