### PR TITLE
test: fix ginkgo extra args

### DIFF
--- a/test/e2e/kubernetes/Makefile
+++ b/test/e2e/kubernetes/Makefile
@@ -4,7 +4,7 @@ K8S_TEST_VERSION ?= v1.36.2
 
 GINKGO = bin/ginkgo
 GINKGO_ARGS = -v --flake-attempts=2
-GINKGO_EXTRA_ARGS ?= ""
+GINKGO_EXTRA_ARGS ?=
 
 E2E = bin/e2e.test
 E2E_ARGS = -storage.testdriver=$(CURDIR)/testdriver.yaml


### PR DESCRIPTION
Ginkgo is bundled through the Kubernetes tests and a recent bump
of Ginkgo lead to a tighter arg parsing.
