### PR TITLE
fix: provision volumes in the correct location with enableProvidedByTopology

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -349,6 +349,7 @@ spec:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
             - --extra-create-metadata
+            - --strict-topology
           volumeMounts:
           - name: socket-dir
             mountPath: /run/csi

--- a/chart/.snapshots/example-prod.yaml
+++ b/chart/.snapshots/example-prod.yaml
@@ -465,6 +465,7 @@ spec:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
             - --extra-create-metadata
+            - --strict-topology
             - --leader-election
             - --leader-election-namespace=kube-system
           volumeMounts:

--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -615,6 +615,7 @@ spec:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
             - --extra-create-metadata
+            - --strict-topology
             - --leader-election
             - --leader-election-namespace=namespace-override
           volumeMounts:

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -200,6 +200,7 @@ spec:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
             - --extra-create-metadata
+            - --strict-topology
             {{- if $enableLeaderElection }}
             - --leader-election
             - --leader-election-namespace={{ include "hcloud-csi.names.namespace" . }}

--- a/deploy/kubernetes/hcloud-csi.yml
+++ b/deploy/kubernetes/hcloud-csi.yml
@@ -386,6 +386,7 @@ spec:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
             - --extra-create-metadata
+            - --strict-topology
           volumeMounts:
           - name: socket-dir
             mountPath: /run/csi

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -79,11 +79,19 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 		}
 	}
 
-	// Take the location where to create the volume from the request's
-	// accessibility requirements, falling back to the location where the
-	// controller pod has been scheduled if no requirements have been provided.
+	// If the CO did send topology requirements but none of them carry a
+	// location segment, we must not silently fall back to the controller's
+	// location: that can provision the volume in a location the selected node
+	// can not reach, leaving the pod unschedulable (see #1428).
 	location := s.location
-	if loc := locationFromTopologyRequirement(req.GetAccessibilityRequirements()); loc != nil {
+	if reqs := req.GetAccessibilityRequirements(); len(reqs.GetPreferred()) > 0 || len(reqs.GetRequisite()) > 0 {
+		loc := locationFromTopologyRequirement(reqs)
+		if loc == nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"accessibility requirements were provided but none contained a %q topology segment; "+
+					"can not determine the location to create the volume in",
+				TopologySegmentLocation)
+		}
 		location = *loc
 	}
 

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -79,10 +79,10 @@ func (s *ControllerService) CreateVolume(ctx context.Context, req *proto.CreateV
 		}
 	}
 
-	// If the CO did send topology requirements but none of them carry a
-	// location segment, we must not silently fall back to the controller's
-	// location: that can provision the volume in a location the selected node
-	// can not reach, leaving the pod unschedulable (see #1428).
+	// If the container orchestration system did send topology requirements but
+	// none of them carry a location segment, we must not silently fall back to
+	// the controller's location: that can provision the volume in a location the
+	// selected node can not reach, leaving the pod unschedulable (see #1428).
 	location := s.location
 	if reqs := req.GetAccessibilityRequirements(); len(reqs.GetPreferred()) > 0 || len(reqs.GetRequisite()) > 0 {
 		loc := locationFromTopologyRequirement(reqs)

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -404,6 +404,36 @@ func TestControllerServiceCreateVolumeInputErrors(t *testing.T) {
 			},
 			Code: codes.InvalidArgument,
 		},
+		{
+			Name: "topology requirement without location segment",
+			Req: &proto.CreateVolumeRequest{
+				Name: "test",
+				CapacityRange: &proto.CapacityRange{
+					RequiredBytes: 5 * GB,
+					LimitBytes:    10 * GB,
+				},
+				VolumeCapabilities: []*proto.VolumeCapability{
+					{
+						AccessType: &proto.VolumeCapability_Mount{
+							Mount: &proto.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &proto.VolumeCapability_AccessMode{
+							Mode: proto.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+				AccessibilityRequirements: &proto.TopologyRequirement{
+					Preferred: []*proto.Topology{
+						{
+							Segments: map[string]string{
+								ProvidedByLabel: "cloud",
+							},
+						},
+					},
+				},
+			},
+			Code: codes.InvalidArgument,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
When enableProvidedByTopology is enabled, the generated StorageClass only
carries the `instance.hetzner.cloud/provided-by` topology segment. Without
`--strict-topology` the external-provisioner uses allowedTopologies as the
requisite topology and drops the selected node's `csi.hetzner.cloud/location`,
so the controller fell back to the controller pod's location and provisioned
volumes in the wrong place, leaving pods unschedulable.

Fixes #1428
