### PR TITLE
fix: verify device identity before publishing volume

### DIFF
--- a/internal/volumes/mount.go
+++ b/internal/volumes/mount.go
@@ -1,6 +1,7 @@
 package volumes
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -163,8 +164,51 @@ func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, devi
 	return s.mounter.FormatAndMountSensitiveWithFormatOptions(devicePath, targetPath, opts.FSType, mountOptions, opts.Additional, formatOptions)
 }
 
-// waitDeviceReady ensures the device at devicePath exists. This is done by ensuring a stat
-// syscall returns no error.
+// HCloudVolumeDevicePrefix is the prefix of the by-id path reported as Volume.LinuxDevice.
+const HCloudVolumeDevicePrefix = "/dev/disk/by-id/scsi-0HC_Volume_"
+
+// sysBlockPath is a variable so tests can point it at a fixture directory.
+var sysBlockPath = "/sys/block"
+
+var ErrDeviceMismatch = errors.New("device path resolves to a different volume")
+
+// verifyDeviceIdentity checks that devicePath resolves to the device of the volume named
+// in the path. The by-id symlinks are maintained asynchronously by udev, so a stale one
+// can resolve to another volume's device. Returns nil when the identity is confirmed and
+// when it cannot be determined, so an unverifiable mount is never blocked.
+func (s *LinuxMountService) verifyDeviceIdentity(devicePath string) error {
+	volumeID, isHCloudVolume := strings.CutPrefix(devicePath, HCloudVolumeDevicePrefix)
+	if !isHCloudVolume {
+		return nil
+	}
+
+	resolved, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		return nil
+	}
+
+	return verifyDeviceSerial(devicePath, resolved, volumeID)
+}
+
+// verifyDeviceSerial compares the SCSI serial of the resolved device against the volume ID.
+func verifyDeviceSerial(devicePath, resolved, volumeID string) error {
+	// VPD page 0x80: a 4 byte header, then the serial, which is the volume ID.
+	raw, err := os.ReadFile(filepath.Join(sysBlockPath, filepath.Base(resolved), "device", "vpd_pg80"))
+	if err != nil || len(raw) <= 4 {
+		return nil
+	}
+
+	serial := string(bytes.Trim(raw[4:], "\x00 "))
+	if serial != volumeID {
+		return fmt.Errorf("%w: %s resolved to %s with serial %q, expected volume %s",
+			ErrDeviceMismatch, devicePath, resolved, serial, volumeID)
+	}
+	return nil
+}
+
+// waitDeviceReady ensures the device at devicePath exists and belongs to the volume named
+// in the path. Existence is checked via stat, otherwise `blkid` might return exit code 2,
+// which is the same exit code as for an unformatted device.
 func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath string) error {
 	const maxRetries = 7
 	backoffFunc := hcloud.ExponentialBackoffWithOpts(hcloud.ExponentialBackoffOpts{
@@ -176,15 +220,19 @@ func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath stri
 	var err error
 	for i := range maxRetries {
 		var stat unix.Stat_t
-		err = unix.Stat(devicePath, &stat)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, unix.ENOENT) {
+		switch err = unix.Stat(devicePath, &stat); {
+		case err == nil:
+			if err = s.verifyDeviceIdentity(devicePath); err == nil {
+				return nil
+			}
+			// udev has not finished updating the symlink yet. Retrying is safe,
+			// mounting the wrong device is not.
+			s.logger.Warn("device not ready yet: path resolves to another volume", "devicePath", devicePath, "error", err)
+		case errors.Is(err, unix.ENOENT):
+			s.logger.Debug("device not ready yet: stat syscall returned ENOENT", "devicePath", devicePath)
+		default:
 			return err
 		}
-
-		s.logger.Debug("device not ready yet: stat syscall returned ENOENT", "devicePath", devicePath)
 
 		if i == maxRetries-1 {
 			break

--- a/internal/volumes/mount.go
+++ b/internal/volumes/mount.go
@@ -184,7 +184,7 @@ func (s *LinuxMountService) verifyDeviceIdentity(devicePath string) error {
 
 	resolved, err := filepath.EvalSymlinks(devicePath)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // identity cannot be determined, so the mount is allowed to proceed
 	}
 
 	return verifyDeviceSerial(devicePath, resolved, volumeID)
@@ -195,7 +195,7 @@ func verifyDeviceSerial(devicePath, resolved, volumeID string) error {
 	// VPD page 0x80: a 4 byte header, then the serial, which is the volume ID.
 	raw, err := os.ReadFile(filepath.Join(sysBlockPath, filepath.Base(resolved), "device", "vpd_pg80"))
 	if err != nil || len(raw) <= 4 {
-		return nil
+		return nil //nolint:nilerr // identity cannot be determined, so the mount is allowed to proceed
 	}
 
 	serial := string(bytes.Trim(raw[4:], "\x00 "))

--- a/internal/volumes/mount_test.go
+++ b/internal/volumes/mount_test.go
@@ -1,3 +1,145 @@
 package volumes
 
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
 var _ MountService = (*LinuxMountService)(nil)
+
+// writeVPD lays out a fake /sys/block/<device>/device/vpd_pg80 holding serial,
+// preceded by the 4 byte VPD page header the kernel emits.
+func writeVPD(t *testing.T, root, device, serial string) {
+	t.Helper()
+
+	dir := filepath.Join(root, device, "device")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	page := append([]byte{0x00, 0x80, 0x00, byte(len(serial))}, []byte(serial)...)
+	if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), page, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// useFakeSysBlock points the serial lookup at a fixture directory.
+func useFakeSysBlock(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	previous := sysBlockPath
+	sysBlockPath = root
+	t.Cleanup(func() { sysBlockPath = previous })
+
+	return root
+}
+
+func TestVerifyDeviceSerial(t *testing.T) {
+	root := useFakeSysBlock(t)
+
+	writeVPD(t, root, "sdc", "106478890")
+	writeVPD(t, root, "sdd", "106486781")
+	// A serial padded the way some kernels report it.
+	writeVPD(t, root, "sde", "106486782  ")
+
+	tests := []struct {
+		name     string
+		resolved string
+		volumeID string
+		wantErr  error
+	}{
+		{
+			name:     "serial matches the requested volume",
+			resolved: "/dev/sdc",
+			volumeID: "106478890",
+		},
+		{
+			name:     "symlink resolves to another volume",
+			resolved: "/dev/sdc",
+			volumeID: "106486781",
+			wantErr:  ErrDeviceMismatch,
+		},
+		{
+			name:     "padded serial is trimmed before comparing",
+			resolved: "/dev/sde",
+			volumeID: "106486782",
+		},
+		{
+			name:     "unknown device cannot be verified and is allowed",
+			resolved: "/dev/sdz",
+			volumeID: "106486781",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyDeviceSerial(HCloudVolumeDevicePrefix+tt.volumeID, tt.resolved, tt.volumeID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("got error %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyDeviceIdentitySkipsForeignPaths(t *testing.T) {
+	useFakeSysBlock(t)
+
+	s := &LinuxMountService{}
+
+	// LUKS mappings and the sanity tests' fake device paths carry no volume ID.
+	for _, devicePath := range []string{"devpath", "/dev/mapper/scsi-0HC_Volume_1", "/dev/sdc"} {
+		if err := s.verifyDeviceIdentity(devicePath); err != nil {
+			t.Errorf("verifyDeviceIdentity(%q) = %v, want nil", devicePath, err)
+		}
+	}
+}
+
+// TestPublishRejectsAliasedDevice covers a stale by-id symlink resolving to another
+// volume's device. Without the identity check, Publish mounts it, or formats it when
+// blkid finds no filesystem, destroying its data (#1346).
+func TestPublishRejectsAliasedDevice(t *testing.T) {
+	byID := filepath.Dir(HCloudVolumeDevicePrefix)
+	if err := os.MkdirAll(byID, 0o755); err != nil {
+		t.Skipf("needs a writable %s: %v", byID, err)
+	}
+
+	// The device of volume 106478890, holding data blkid does not recognise.
+	deviceOfOtherVolume := "/dev/sdc-aliased"
+	payload := bytes.Repeat([]byte("data-of-volume-106478890."), 40)
+	if err := os.WriteFile(deviceOfOtherVolume, payload, 0o644); err != nil {
+		t.Skipf("needs a writable /dev: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(deviceOfOtherVolume) })
+
+	root := useFakeSysBlock(t)
+	writeVPD(t, root, filepath.Base(deviceOfOtherVolume), "106478890")
+
+	requestedPath := HCloudVolumeDevicePrefix + "106486781"
+	_ = os.Remove(requestedPath)
+	if err := os.Symlink(deviceOfOtherVolume, requestedPath); err != nil {
+		t.Skipf("needs a writable /dev: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(requestedPath) })
+
+	s := NewLinuxMountService(slog.Default())
+
+	err := s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), requestedPath, MountOpts{})
+	if !errors.Is(err, ErrDeviceMismatch) {
+		t.Fatalf("Publish(%s) = %v, want %v: it mounted the device holding volume 106478890 "+
+			"after being asked for volume 106486781", requestedPath, err, ErrDeviceMismatch)
+	}
+
+	after, err := os.ReadFile(deviceOfOtherVolume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(payload, after) {
+		t.Fatalf("volume 106478890's data was modified while refusing to publish volume 106486781")
+	}
+}

--- a/internal/volumes/mount_test.go
+++ b/internal/volumes/mount_test.go
@@ -18,12 +18,15 @@ func writeVPD(t *testing.T, root, device, serial string) {
 	t.Helper()
 
 	dir := filepath.Join(root, device, "device")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		t.Fatal(err)
 	}
 
-	page := append([]byte{0x00, 0x80, 0x00, byte(len(serial))}, []byte(serial)...)
-	if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), page, 0o644); err != nil {
+	if len(serial) > 255 {
+		t.Fatalf("test serial %q longer than a byte can encode", serial)
+	}
+	page := append([]byte{0x00, 0x80, 0x00, byte(len(serial))}, []byte(serial)...) //nolint:gosec // bounds-checked above
+	if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), page, 0o600); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -105,14 +108,14 @@ func TestVerifyDeviceIdentitySkipsForeignPaths(t *testing.T) {
 // blkid finds no filesystem, destroying its data (#1346).
 func TestPublishRejectsAliasedDevice(t *testing.T) {
 	byID := filepath.Dir(HCloudVolumeDevicePrefix)
-	if err := os.MkdirAll(byID, 0o755); err != nil {
+	if err := os.MkdirAll(byID, 0o750); err != nil {
 		t.Skipf("needs a writable %s: %v", byID, err)
 	}
 
 	// The device of volume 106478890, holding data blkid does not recognise.
 	deviceOfOtherVolume := "/dev/sdc-aliased"
 	payload := bytes.Repeat([]byte("data-of-volume-106478890."), 40)
-	if err := os.WriteFile(deviceOfOtherVolume, payload, 0o644); err != nil {
+	if err := os.WriteFile(deviceOfOtherVolume, payload, 0o600); err != nil {
 		t.Skipf("needs a writable /dev: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(deviceOfOtherVolume) })


### PR DESCRIPTION
## Problem

`NodePublishVolume` trusts the device path from `PublishContext` verbatim. `waitDeviceReady` only checks that the `/dev/disk/by-id` path exists, not that it points at the requested volume. The symlinks are maintained asynchronously by udev, so at boot with several volumes attaching, a path can resolve to another volume's block device.

Publish then proceeds on the wrong device:

- If it carries a filesystem, it is mounted and two volumes share one disk (hetznercloud/csi-driver#1455, production incident with SELinux lockout and cross-volume writes).
- If blkid finds no filesystem, it is formatted. The data is destroyed even when the subsequent mount fails. Same outcome as #1346, reached through a different route.

Both were reproduced against current `main` at the `Publish` level (mkfs ran and zeroed a data-carrying aliased device).

## Fix

After the existing stat check, resolve the symlink and compare the device's SCSI serial (`/sys/block/<dev>/device/vpd_pg80`, which Hetzner sets to the volume ID) against the ID in the path. A mismatch is retried inside the existing backoff loop, treating a stale symlink like one that does not exist yet, and ends in `ErrDeviceMismatch` instead of a wrong mount.

Verification fails open: non Hetzner paths, LUKS mappings, or an unreadable VPD page skip the check, so a mount that cannot be verified is never blocked. The VPD layout (4 byte header, then the volume ID) was confirmed against production nodes.

## Tests

- `TestPublishRejectsAliasedDevice`: aliased by-id path at the `Publish` entry point, asserts `ErrDeviceMismatch` and that the aliased device's data is untouched. Needs a writable `/dev`, skips otherwise.
- `TestVerifyDeviceSerial`: match, mismatch, kernel padded serial, unverifiable device.
- `TestVerifyDeviceIdentitySkipsForeignPaths`: LUKS mappings and the sanity tests' fake `devpath` are never rejected.

Full suite passes; `go vet` and `gofmt` clean.

Refs hetznercloud/csi-driver#1455

This PR (and code) were written using Claude Opus 5 assistance