### PR TITLE
fix: verify device identity before mounting

### DIFF
--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -62,8 +62,12 @@ func (s *NodeService) NodePublishVolume(ctx context.Context, req *proto.NodePubl
 		return nil, status.Error(codes.InvalidArgument, "missing target path")
 	}
 
-	devicePath := req.GetPublishContext()["devicePath"]
-	if devicePath == "" {
+	// The device path the controller published is not used to find the device: it names
+	// a by-id symlink, which udev maintains asynchronously, so it can still point at the
+	// device of another volume. The device is looked up by the serial the kernel reports
+	// for it instead. The publish context entry is still required, as its presence is how
+	// the CO signals that the volume was attached to this node.
+	if req.GetPublishContext()["devicePath"] == "" {
 		return nil, status.Error(codes.InvalidArgument, "missing device path")
 	}
 
@@ -87,7 +91,7 @@ func (s *NodeService) NodePublishVolume(ctx context.Context, req *proto.NodePubl
 		return nil, status.Error(codes.InvalidArgument, "publish volume: unsupported volume capability")
 	}
 
-	if err := s.volumeMountService.Publish(ctx, req.GetTargetPath(), devicePath, opts); err != nil {
+	if err := s.volumeMountService.Publish(ctx, req.GetTargetPath(), req.GetVolumeId(), opts); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to publish volume: %s", err))
 	}
 	return &proto.NodePublishVolumeResponse{}, nil

--- a/internal/driver/node_test.go
+++ b/internal/driver/node_test.go
@@ -48,12 +48,12 @@ func newNodeServerTestEnv() nodeServiceTestEnv {
 func TestNodeServiceNodePublishVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.PublishFunc = func(ctx context.Context, targetPath string, devicePath string, opts volumes.MountOpts) error {
+	env.volumeMountService.PublishFunc = func(ctx context.Context, targetPath string, volumeID string, opts volumes.MountOpts) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path passed to volume service: %s", targetPath)
 		}
-		if devicePath != "devpath" {
-			t.Errorf("unexpected device path passed to volume mount service: %s", devicePath)
+		if volumeID != "1" {
+			t.Errorf("unexpected volume id passed to volume mount service: %s", volumeID)
 		}
 		return nil
 	}
@@ -85,13 +85,13 @@ func TestNodeServiceNodePublishBlockVolume(t *testing.T) {
 	env := newNodeServerTestEnv()
 
 	env.volumeMountService.PublishFunc = func(
-		ctx context.Context, targetPath, devicePath string, opts volumes.MountOpts,
+		ctx context.Context, targetPath, volumeID string, opts volumes.MountOpts,
 	) error {
 		if targetPath != "target" {
 			t.Errorf("unexpected target path: %s", targetPath)
 		}
-		if devicePath != "devpath" {
-			t.Errorf("unexpected device path: %s", devicePath)
+		if volumeID != "1" {
+			t.Errorf("unexpected volume id: %s", volumeID)
 		}
 		return nil
 	}
@@ -117,7 +117,7 @@ func TestNodeServiceNodePublishBlockVolume(t *testing.T) {
 func TestNodeServiceNodePublishPublishError(t *testing.T) {
 	env := newNodeServerTestEnv()
 
-	env.volumeMountService.PublishFunc = func(ctx context.Context, targetPath string, devicePath string, opts volumes.MountOpts) error {
+	env.volumeMountService.PublishFunc = func(ctx context.Context, targetPath string, volumeID string, opts volumes.MountOpts) error {
 		return io.EOF
 	}
 

--- a/internal/mock/volume.go
+++ b/internal/mock/volume.go
@@ -77,16 +77,16 @@ func (s *VolumeService) Resize(ctx context.Context, volume *csi.Volume, size int
 }
 
 type VolumeMountService struct {
-	PublishFunc    func(ctx context.Context, targetPath string, devicePath string, opts volumes.MountOpts) error
+	PublishFunc    func(ctx context.Context, targetPath string, volumeID string, opts volumes.MountOpts) error
 	UnpublishFunc  func(ctx context.Context, targetPath string) error
 	PathExistsFunc func(path string) (bool, error)
 }
 
-func (s *VolumeMountService) Publish(ctx context.Context, targetPath string, devicePath string, opts volumes.MountOpts) error {
+func (s *VolumeMountService) Publish(ctx context.Context, targetPath string, volumeID string, opts volumes.MountOpts) error {
 	if s.PublishFunc == nil {
 		panic("not implemented")
 	}
-	return s.PublishFunc(ctx, targetPath, devicePath, opts)
+	return s.PublishFunc(ctx, targetPath, volumeID, opts)
 }
 
 func (s *VolumeMountService) Unpublish(ctx context.Context, targetPath string) error {

--- a/internal/volumes/deviceidentity.go
+++ b/internal/volumes/deviceidentity.go
@@ -10,16 +10,14 @@ import (
 )
 
 var (
-	// volumeDevicePrefix is the prefix of the by-id path reported as Volume.LinuxDevice.
-	// It is a variable so tests can point it at a fixture directory.
 	volumeDevicePrefix = "/dev/disk/by-id/scsi-0HC_Volume_"
-	// sysClassBlockPath is a variable so tests can point it at a fixture directory.
-	sysClassBlockPath = "/sys/class/block"
+	devPath            = "/dev"
+	sysClassBlockPath  = "/sys/class/block"
 )
 
 var (
-	errDeviceMismatch     = errors.New("device path resolves to a different volume")
-	errNotVolume          = errors.New("device is not a hetzner cloud volume")
+	errDeviceNotFound     = errors.New("no block device reports the volume as its serial")
+	errAmbiguousDevice    = errors.New("multiple block devices report the volume as their serial")
 	errEmptySerial        = errors.New("vpd_pg80: empty serial")
 	errAllPadding         = errors.New("vpd_pg80: serial is all padding")
 	errShortPage          = errors.New("vpd_pg80: page is shorter than the 4 byte header")
@@ -27,38 +25,38 @@ var (
 	errPageLengthTooLarge = errors.New("vpd_pg80: page length exceeds the bytes read")
 )
 
-// VerifyDeviceIdentity checks that devicePath resolves to the device of the volume named
-// in the path, by comparing the SCSI serial of the resolved device against the volume ID.
-// The by-id symlinks are maintained asynchronously by udev, so a stale one can resolve to
-// another volume's device. An identity that cannot be determined is an error: mounting the
-// wrong device destroys data, refusing to mount does not.
-func VerifyDeviceIdentity(devicePath string) error {
-	volumeID, isHCloudVolume := strings.CutPrefix(devicePath, volumeDevicePrefix)
-	if !isHCloudVolume {
-		return fmt.Errorf("%w: %s", errNotVolume, devicePath)
-	}
+func VolumeDevicePath(volumeID string) string {
+	return volumeDevicePrefix + volumeID
+}
 
-	resolved, err := filepath.EvalSymlinks(devicePath)
+func DeviceForVolume(volumeID string) (string, error) {
+	entries, err := os.ReadDir(sysClassBlockPath)
 	if err != nil {
-		return err
+		return "", fmt.Errorf("list block devices: %w", err)
 	}
 
-	serial, err := readDiskSerial(resolved)
-	if err != nil {
-		return fmt.Errorf("can't verify serial of volume %s: %w", volumeID, err)
+	var found []string
+	for _, entry := range entries {
+		serial, err := readDiskSerial(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		if serial == volumeID {
+			found = append(found, entry.Name())
+		}
 	}
 
-	if serial != volumeID {
-		return fmt.Errorf(
-			"%w: got serial %s for device %s, expected volume %s",
-			errDeviceMismatch,
-			serial,
-			devicePath,
-			volumeID,
-		)
+	switch len(found) {
+	case 1:
+		return filepath.Join(devPath, found[0]), nil
+	case 0:
+		return "", fmt.Errorf("%w: volume %s", errDeviceNotFound, volumeID)
+	default:
+		// Two devices claiming the same volume means the node can not tell them apart.
+		// Refusing is the only safe answer: mounting the wrong one destroys data.
+		return "", fmt.Errorf("%w: volume %s: %s", errAmbiguousDevice, volumeID, strings.Join(found, ", "))
 	}
-
-	return nil
 }
 
 // readDiskSerial reads the SCSI serial of a block device from sysfs. dev is either a

--- a/internal/volumes/deviceidentity.go
+++ b/internal/volumes/deviceidentity.go
@@ -15,6 +15,11 @@ var (
 	sysClassBlockPath  = "/sys/class/block"
 )
 
+func SetDeviceIdentityPaths(dev, sysClassBlock string) {
+	devPath = dev
+	sysClassBlockPath = sysClassBlock
+}
+
 var (
 	errDeviceNotFound     = errors.New("no block device reports the volume as its serial")
 	errAmbiguousDevice    = errors.New("multiple block devices report the volume as their serial")

--- a/internal/volumes/deviceidentity.go
+++ b/internal/volumes/deviceidentity.go
@@ -1,0 +1,99 @@
+package volumes
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// volumeDevicePrefix is the prefix of the by-id path reported as Volume.LinuxDevice.
+	// It is a variable so tests can point it at a fixture directory.
+	volumeDevicePrefix = "/dev/disk/by-id/scsi-0HC_Volume_"
+	// sysClassBlockPath is a variable so tests can point it at a fixture directory.
+	sysClassBlockPath = "/sys/class/block"
+)
+
+var (
+	errDeviceMismatch     = errors.New("device path resolves to a different volume")
+	errNotVolume          = errors.New("device is not a hetzner cloud volume")
+	errEmptySerial        = errors.New("vpd_pg80: empty serial")
+	errAllPadding         = errors.New("vpd_pg80: serial is all padding")
+	errShortPage          = errors.New("vpd_pg80: page is shorter than the 4 byte header")
+	errWrongPageCode      = errors.New("vpd_pg80: unexpected page code")
+	errPageLengthTooLarge = errors.New("vpd_pg80: page length exceeds the bytes read")
+)
+
+// VerifyDeviceIdentity checks that devicePath resolves to the device of the volume named
+// in the path, by comparing the SCSI serial of the resolved device against the volume ID.
+// The by-id symlinks are maintained asynchronously by udev, so a stale one can resolve to
+// another volume's device. An identity that cannot be determined is an error: mounting the
+// wrong device destroys data, refusing to mount does not.
+func VerifyDeviceIdentity(devicePath string) error {
+	volumeID, isHCloudVolume := strings.CutPrefix(devicePath, volumeDevicePrefix)
+	if !isHCloudVolume {
+		return fmt.Errorf("%w: %s", errNotVolume, devicePath)
+	}
+
+	resolved, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		return err
+	}
+
+	serial, err := readDiskSerial(resolved)
+	if err != nil {
+		return fmt.Errorf("can't verify serial of volume %s: %w", volumeID, err)
+	}
+
+	if serial != volumeID {
+		return fmt.Errorf(
+			"%w: got serial %s for device %s, expected volume %s",
+			errDeviceMismatch,
+			serial,
+			devicePath,
+			volumeID,
+		)
+	}
+
+	return nil
+}
+
+// readDiskSerial reads the SCSI serial of a block device from sysfs. dev is either a
+// kernel device name ("sdc") or a path to one ("/dev/sdc").
+func readDiskSerial(dev string) (string, error) {
+	path := filepath.Join(sysClassBlockPath, filepath.Base(dev), "device", "vpd_pg80")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	return parseVPDPG80(b)
+}
+
+func parseVPDPG80(b []byte) (string, error) {
+	if len(b) < 4 {
+		return "", fmt.Errorf("%w: got %d bytes", errShortPage, len(b))
+	}
+
+	if b[1] != 0x80 {
+		return "", fmt.Errorf("%w: 0x%02x", errWrongPageCode, b[1])
+	}
+
+	n := int(binary.BigEndian.Uint16(b[2:4]))
+	if n == 0 {
+		return "", errEmptySerial
+	}
+
+	if payloadLen := len(b) - 4; n > payloadLen {
+		return "", fmt.Errorf("%w: got %d bytes", errPageLengthTooLarge, payloadLen)
+	}
+
+	serial := strings.Trim(string(b[4:4+n]), " \x00")
+	if serial == "" {
+		return "", errAllPadding
+	}
+
+	return serial, nil
+}

--- a/internal/volumes/deviceidentity_integration.go
+++ b/internal/volumes/deviceidentity_integration.go
@@ -2,17 +2,7 @@
 
 package volumes
 
-// SetDeviceIdentityPaths points the device identity check at fixture directories.
-//
-// The integration tests publish files used as fake devices. Those have neither a by-id
-// symlink, which udev maintains on a node, nor a vpd_pg80, which the kernel exposes for a
-// SCSI disk and which can not be created because sysfs is not writable. The tests create
-// both under a temporary directory and call this, so that publishing takes the same path
-// it takes on a node instead of one that skips the check.
-//
-// This file is only built with the `integration` build tag, so the paths of the shipped
-// driver can not be redirected.
-func SetDeviceIdentityPaths(byIDPrefix, sysClassBlock string) {
-	volumeDevicePrefix = byIDPrefix
+func SetDeviceIdentityPaths(dev, sysClassBlock string) {
+	devPath = dev
 	sysClassBlockPath = sysClassBlock
 }

--- a/internal/volumes/deviceidentity_integration.go
+++ b/internal/volumes/deviceidentity_integration.go
@@ -1,8 +1,0 @@
-//go:build integration
-
-package volumes
-
-func SetDeviceIdentityPaths(dev, sysClassBlock string) {
-	devPath = dev
-	sysClassBlockPath = sysClassBlock
-}

--- a/internal/volumes/deviceidentity_integration.go
+++ b/internal/volumes/deviceidentity_integration.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package volumes
+
+// SetDeviceIdentityPaths points the device identity check at fixture directories.
+//
+// The integration tests publish files used as fake devices. Those have neither a by-id
+// symlink, which udev maintains on a node, nor a vpd_pg80, which the kernel exposes for a
+// SCSI disk and which can not be created because sysfs is not writable. The tests create
+// both under a temporary directory and call this, so that publishing takes the same path
+// it takes on a node instead of one that skips the check.
+//
+// This file is only built with the `integration` build tag, so the paths of the shipped
+// driver can not be redirected.
+func SetDeviceIdentityPaths(byIDPrefix, sysClassBlock string) {
+	volumeDevicePrefix = byIDPrefix
+	sysClassBlockPath = sysClassBlock
+}

--- a/internal/volumes/deviceidentity_test.go
+++ b/internal/volumes/deviceidentity_test.go
@@ -1,0 +1,313 @@
+package volumes
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// vpdPage lays out the bytes the kernel exposes as vpd_pg80: a 4 byte header whose last
+// two bytes hold the length of the serial that follows.
+func vpdPage(t *testing.T, serial string) []byte {
+	t.Helper()
+
+	if len(serial) > math.MaxUint16 {
+		t.Fatalf("test serial of %d bytes does not fit the vpd page length field", len(serial))
+	}
+
+	page := make([]byte, 4, 4+len(serial))
+	page[1] = 0x80
+	binary.BigEndian.PutUint16(page[2:4], uint16(len(serial))) //nolint:gosec // bounds-checked above
+
+	return append(page, serial...)
+}
+
+// fakeSysClassBlock points the serial lookup at a fixture directory and returns it.
+// It swaps a package level variable, so its callers must not run in parallel.
+func fakeSysClassBlock(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	previous := sysClassBlockPath
+	sysClassBlockPath = root
+	t.Cleanup(func() { sysClassBlockPath = previous })
+
+	return root
+}
+
+// writeVPD creates the sysfs entry reporting serial for device.
+func writeVPD(t *testing.T, root, device string, page []byte) {
+	t.Helper()
+
+	dir := filepath.Join(root, device, "device")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), page, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fakeByID points the by-id prefix at a fixture directory, so the tests need neither a
+// writable /dev nor a writable /sys. It returns a function creating a by-id symlink to a
+// device file, mirroring what udev maintains on a node. It swaps a package level variable,
+// so its callers must not run in parallel.
+func fakeByID(t *testing.T) (link func(volumeID, device string) string, byIDPrefix string) {
+	t.Helper()
+
+	root := t.TempDir()
+	previous := volumeDevicePrefix
+	volumeDevicePrefix = filepath.Join(root, "by-id", "scsi-0HC_Volume_")
+	t.Cleanup(func() { volumeDevicePrefix = previous })
+
+	if err := os.MkdirAll(filepath.Join(root, "by-id"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "dev"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	link = func(volumeID, device string) string {
+		t.Helper()
+
+		devicePath := filepath.Join(root, "dev", device)
+		if err := os.WriteFile(devicePath, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		byIDPath := volumeDevicePrefix + volumeID
+		if err := os.Symlink(devicePath, byIDPath); err != nil {
+			t.Fatal(err)
+		}
+		return byIDPath
+	}
+
+	return link, volumeDevicePrefix
+}
+
+func TestParseVPDPG80(t *testing.T) {
+	tests := []struct {
+		name       string
+		page       []byte
+		wantSerial string
+		wantErr    error
+	}{
+		{
+			name:       "serial of an hcloud volume",
+			page:       vpdPage(t, "106478890"),
+			wantSerial: "106478890",
+		},
+		{
+			name:       "trailing spaces are trimmed",
+			page:       vpdPage(t, "106478890  "),
+			wantSerial: "106478890",
+		},
+		{
+			name:       "trailing NUL bytes are trimmed",
+			page:       vpdPage(t, "106478890\x00\x00"),
+			wantSerial: "106478890",
+		},
+		{
+			name:       "page length shorter than the payload wins",
+			page:       append(vpdPage(t, "106478890"), []byte("trailing junk")...),
+			wantSerial: "106478890",
+		},
+		{
+			// A page longer than 255 bytes needs both length bytes to be read.
+			name:       "serial padded past a single length byte",
+			page:       vpdPage(t, strings.Repeat("\x00", 300)+"106478890"),
+			wantSerial: "106478890",
+		},
+		{
+			name:    "empty page",
+			page:    nil,
+			wantErr: errShortPage,
+		},
+		{
+			name:    "header only, truncated",
+			page:    []byte{0x00, 0x80, 0x00},
+			wantErr: errShortPage,
+		},
+		{
+			name:    "another vpd page",
+			page:    []byte{0x00, 0x83, 0x00, 0x04, 'a', 'b', 'c', 'd'},
+			wantErr: errWrongPageCode,
+		},
+		{
+			name:    "no serial reported",
+			page:    vpdPage(t, ""),
+			wantErr: errEmptySerial,
+		},
+		{
+			name:    "serial is only padding",
+			page:    vpdPage(t, " \x00 "),
+			wantErr: errAllPadding,
+		},
+		{
+			name:    "page length exceeds the bytes read",
+			page:    []byte{0x00, 0x80, 0x00, 0x09, '1', '0', '6'},
+			wantErr: errPageLengthTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serial, err := parseVPDPG80(tt.page)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("ParseVPDPG80() error = %v, want %v", err, tt.wantErr)
+				}
+				if serial != "" {
+					t.Errorf("ParseVPDPG80() serial = %q, want empty on error", serial)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseVPDPG80() error = %v, want nil", err)
+			}
+			if serial != tt.wantSerial {
+				t.Errorf("ParseVPDPG80() serial = %q, want %q", serial, tt.wantSerial)
+			}
+		})
+	}
+}
+
+func TestReadDiskSerial(t *testing.T) {
+	root := fakeSysClassBlock(t)
+	writeVPD(t, root, "sdc", vpdPage(t, "106478890"))
+
+	t.Run("kernel device name", func(t *testing.T) {
+		serial, err := readDiskSerial("sdc")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if serial != "106478890" {
+			t.Errorf("ReadDiskSerial() = %q, want %q", serial, "106478890")
+		}
+	})
+
+	// VerifyDeviceIdentity passes the path EvalSymlinks resolved to, not a bare name.
+	t.Run("resolved device path", func(t *testing.T) {
+		serial, err := readDiskSerial("/dev/sdc")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if serial != "106478890" {
+			t.Errorf("ReadDiskSerial() = %q, want %q", serial, "106478890")
+		}
+	})
+
+	t.Run("device without a vpd_pg80", func(t *testing.T) {
+		if _, err := readDiskSerial("sdz"); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("ReadDiskSerial() error = %v, want %v", err, os.ErrNotExist)
+		}
+	})
+
+	t.Run("unparsable page", func(t *testing.T) {
+		writeVPD(t, root, "sdd", []byte{0x00, 0x80})
+		if _, err := readDiskSerial("sdd"); !errors.Is(err, errShortPage) {
+			t.Fatalf("ReadDiskSerial() error = %v, want %v", err, errShortPage)
+		}
+	})
+}
+
+func TestVerifyDeviceIdentity(t *testing.T) {
+	sysRoot := fakeSysClassBlock(t)
+	link, byIDPrefix := fakeByID(t)
+
+	writeVPD(t, sysRoot, "sdc", vpdPage(t, "106478890"))
+	writeVPD(t, sysRoot, "sdd", vpdPage(t, "106486781  "))
+	writeVPD(t, sysRoot, "sdf", vpdPage(t, ""))
+
+	// udev pointed the by-id link of volume 106486782 at the device of volume 106478890.
+	staleLink := link("106486782", "sdc")
+	matching := link("106486781", "sdd")
+	noSerial := link("106486783", "sdf")
+	noVPD := link("106486784", "sde")
+
+	dangling := byIDPrefix + "106486785"
+	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), dangling); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		devicePath string
+		wantErr    error
+	}{
+		{
+			name:       "serial matches the requested volume",
+			devicePath: matching,
+		},
+		{
+			name:       "by-id link resolves to another volume's device",
+			devicePath: staleLink,
+			wantErr:    errDeviceMismatch,
+		},
+		{
+			name:       "device is not an hcloud volume",
+			devicePath: "/dev/mapper/scsi-0HC_Volume_106478890",
+			wantErr:    errNotVolume,
+		},
+		{
+			name:       "device path carries no volume id",
+			devicePath: "devpath",
+			wantErr:    errNotVolume,
+		},
+		{
+			name:       "by-id link does not exist",
+			devicePath: byIDPrefix + "106486786",
+			wantErr:    os.ErrNotExist,
+		},
+		{
+			name:       "by-id link resolves to a missing device",
+			devicePath: dangling,
+			wantErr:    os.ErrNotExist,
+		},
+		{
+			name:       "device reports no serial",
+			devicePath: noSerial,
+			wantErr:    errEmptySerial,
+		},
+		{
+			name:       "device exposes no vpd_pg80",
+			devicePath: noVPD,
+			wantErr:    os.ErrNotExist,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyDeviceIdentity(tt.devicePath)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("VerifyDeviceIdentity(%s) = %v, want %v", tt.devicePath, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestVerifyDeviceIdentityNamesTheVolume covers the message an operator sees when a mount
+// is refused: it has to name both volumes to be actionable.
+func TestVerifyDeviceIdentityNamesTheVolume(t *testing.T) {
+	sysRoot := fakeSysClassBlock(t)
+	link, _ := fakeByID(t)
+
+	writeVPD(t, sysRoot, "sdc", vpdPage(t, "106478890"))
+	staleLink := link("106486781", "sdc")
+
+	err := VerifyDeviceIdentity(staleLink)
+	if err == nil {
+		t.Fatal("VerifyDeviceIdentity() = nil, want an error")
+	}
+	for _, want := range []string{"106478890", "106486781"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention volume %s", err, want)
+		}
+	}
+}

--- a/internal/volumes/deviceidentity_test.go
+++ b/internal/volumes/deviceidentity_test.go
@@ -26,6 +26,38 @@ func vpdPage(t *testing.T, serial string) []byte {
 	return append(page, serial...)
 }
 
+func fakeNode(t *testing.T) (attach func(device string, page []byte) string, devRoot string) {
+	t.Helper()
+
+	root := t.TempDir()
+	devRoot = filepath.Join(root, "dev")
+	sysRoot := filepath.Join(root, "sys", "class", "block")
+
+	for _, dir := range []string{devRoot, sysRoot} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	previousDev, previousSys := devPath, sysClassBlockPath
+	devPath, sysClassBlockPath = devRoot, sysRoot
+	t.Cleanup(func() { devPath, sysClassBlockPath = previousDev, previousSys })
+
+	attach = func(device string, page []byte) string {
+		t.Helper()
+
+		devicePath := filepath.Join(devRoot, device)
+		if err := os.WriteFile(devicePath, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		writeVPD(t, sysRoot, device, page)
+
+		return devicePath
+	}
+
+	return attach, devRoot
+}
+
 // fakeSysClassBlock points the serial lookup at a fixture directory and returns it.
 // It swaps a package level variable, so its callers must not run in parallel.
 func fakeSysClassBlock(t *testing.T) string {
@@ -39,7 +71,8 @@ func fakeSysClassBlock(t *testing.T) string {
 	return root
 }
 
-// writeVPD creates the sysfs entry reporting serial for device.
+// writeVPD creates the sysfs entry reporting serial for device. A nil page leaves the
+// entry without a vpd_pg80, as a device that is not a SCSI disk has.
 func writeVPD(t *testing.T, root, device string, page []byte) {
 	t.Helper()
 
@@ -47,46 +80,12 @@ func writeVPD(t *testing.T, root, device string, page []byte) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		t.Fatal(err)
 	}
+	if page == nil {
+		return
+	}
 	if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), page, 0o600); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// fakeByID points the by-id prefix at a fixture directory, so the tests need neither a
-// writable /dev nor a writable /sys. It returns a function creating a by-id symlink to a
-// device file, mirroring what udev maintains on a node. It swaps a package level variable,
-// so its callers must not run in parallel.
-func fakeByID(t *testing.T) (link func(volumeID, device string) string, byIDPrefix string) {
-	t.Helper()
-
-	root := t.TempDir()
-	previous := volumeDevicePrefix
-	volumeDevicePrefix = filepath.Join(root, "by-id", "scsi-0HC_Volume_")
-	t.Cleanup(func() { volumeDevicePrefix = previous })
-
-	if err := os.MkdirAll(filepath.Join(root, "by-id"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(root, "dev"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-
-	link = func(volumeID, device string) string {
-		t.Helper()
-
-		devicePath := filepath.Join(root, "dev", device)
-		if err := os.WriteFile(devicePath, nil, 0o600); err != nil {
-			t.Fatal(err)
-		}
-
-		byIDPath := volumeDevicePrefix + volumeID
-		if err := os.Symlink(devicePath, byIDPath); err != nil {
-			t.Fatal(err)
-		}
-		return byIDPath
-	}
-
-	return link, volumeDevicePrefix
 }
 
 func TestParseVPDPG80(t *testing.T) {
@@ -192,7 +191,7 @@ func TestReadDiskSerial(t *testing.T) {
 		}
 	})
 
-	// VerifyDeviceIdentity passes the path EvalSymlinks resolved to, not a bare name.
+	// Callers pass a device path as well as a bare kernel device name.
 	t.Run("resolved device path", func(t *testing.T) {
 		serial, err := readDiskSerial("/dev/sdc")
 		if err != nil {
@@ -217,97 +216,99 @@ func TestReadDiskSerial(t *testing.T) {
 	})
 }
 
-func TestVerifyDeviceIdentity(t *testing.T) {
-	sysRoot := fakeSysClassBlock(t)
-	link, byIDPrefix := fakeByID(t)
+func TestDeviceForVolume(t *testing.T) {
+	attach, devRoot := fakeNode(t)
 
-	writeVPD(t, sysRoot, "sdc", vpdPage(t, "106478890"))
-	writeVPD(t, sysRoot, "sdd", vpdPage(t, "106486781  "))
-	writeVPD(t, sysRoot, "sdf", vpdPage(t, ""))
-
-	// udev pointed the by-id link of volume 106486782 at the device of volume 106478890.
-	staleLink := link("106486782", "sdc")
-	matching := link("106486781", "sdd")
-	noSerial := link("106486783", "sdf")
-	noVPD := link("106486784", "sde")
-
-	dangling := byIDPrefix + "106486785"
-	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), dangling); err != nil {
+	attach("sdc", vpdPage(t, "106478890"))
+	attach("sdd", vpdPage(t, "106486781  "))
+	// A device without a readable serial is never a match, even if it is the only one.
+	attach("sde", nil)
+	attach("sdf", vpdPage(t, ""))
+	// Two devices reporting the same volume: the node can not tell them apart.
+	attach("sdg", vpdPage(t, "106486799"))
+	attach("sdh", vpdPage(t, "106486799"))
+	// A partition has no device directory at all.
+	if err := os.MkdirAll(filepath.Join(sysClassBlockPath, "sdc1"), 0o750); err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
-		name       string
-		devicePath string
-		wantErr    error
+		name     string
+		volumeID string
+		wantPath string
+		wantErr  error
 	}{
 		{
-			name:       "serial matches the requested volume",
-			devicePath: matching,
+			name:     "device reporting the volume",
+			volumeID: "106478890",
+			wantPath: filepath.Join(devRoot, "sdc"),
 		},
 		{
-			name:       "by-id link resolves to another volume's device",
-			devicePath: staleLink,
-			wantErr:    errDeviceMismatch,
+			name:     "serial is padded",
+			volumeID: "106486781",
+			wantPath: filepath.Join(devRoot, "sdd"),
 		},
 		{
-			name:       "device is not an hcloud volume",
-			devicePath: "/dev/mapper/scsi-0HC_Volume_106478890",
-			wantErr:    errNotVolume,
+			name:     "no device reports the volume",
+			volumeID: "106486782",
+			wantErr:  errDeviceNotFound,
 		},
 		{
-			name:       "device path carries no volume id",
-			devicePath: "devpath",
-			wantErr:    errNotVolume,
-		},
-		{
-			name:       "by-id link does not exist",
-			devicePath: byIDPrefix + "106486786",
-			wantErr:    os.ErrNotExist,
-		},
-		{
-			name:       "by-id link resolves to a missing device",
-			devicePath: dangling,
-			wantErr:    os.ErrNotExist,
-		},
-		{
-			name:       "device reports no serial",
-			devicePath: noSerial,
-			wantErr:    errEmptySerial,
-		},
-		{
-			name:       "device exposes no vpd_pg80",
-			devicePath: noVPD,
-			wantErr:    os.ErrNotExist,
+			name:     "two devices report the volume",
+			volumeID: "106486799",
+			wantErr:  errAmbiguousDevice,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := VerifyDeviceIdentity(tt.devicePath)
+			devicePath, err := DeviceForVolume(tt.volumeID)
+
 			if !errors.Is(err, tt.wantErr) {
-				t.Fatalf("VerifyDeviceIdentity(%s) = %v, want %v", tt.devicePath, err, tt.wantErr)
+				t.Fatalf("DeviceForVolume(%s) error = %v, want %v", tt.volumeID, err, tt.wantErr)
+			}
+			if devicePath != tt.wantPath {
+				t.Errorf("DeviceForVolume(%s) = %q, want %q", tt.volumeID, devicePath, tt.wantPath)
 			}
 		})
 	}
 }
 
-// TestVerifyDeviceIdentityNamesTheVolume covers the message an operator sees when a mount
-// is refused: it has to name both volumes to be actionable.
-func TestVerifyDeviceIdentityNamesTheVolume(t *testing.T) {
-	sysRoot := fakeSysClassBlock(t)
-	link, _ := fakeByID(t)
+func TestDeviceForVolumeIgnoresByIDLinks(t *testing.T) {
+	attach, devRoot := fakeNode(t)
 
-	writeVPD(t, sysRoot, "sdc", vpdPage(t, "106478890"))
-	staleLink := link("106486781", "sdc")
+	attach("sdc", vpdPage(t, "106478890"))
+	attach("sdd", vpdPage(t, "106486781"))
 
-	err := VerifyDeviceIdentity(staleLink)
-	if err == nil {
-		t.Fatal("VerifyDeviceIdentity() = nil, want an error")
+	// udev points the by-id link of volume 106486781 at the device of volume 106478890,
+	// and has not created one for volume 106478890 at all.
+	byID := filepath.Join(t.TempDir(), "by-id")
+	if err := os.MkdirAll(byID, 0o750); err != nil {
+		t.Fatal(err)
 	}
-	for _, want := range []string{"106478890", "106486781"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q does not mention volume %s", err, want)
+	if err := os.Symlink(filepath.Join(devRoot, "sdc"), filepath.Join(byID, "scsi-0HC_Volume_106486781")); err != nil {
+		t.Fatal(err)
+	}
+
+	for volumeID, want := range map[string]string{"106478890": "sdc", "106486781": "sdd"} {
+		devicePath, err := DeviceForVolume(volumeID)
+		if err != nil {
+			t.Fatalf("DeviceForVolume(%s) = %v", volumeID, err)
 		}
+		if devicePath != filepath.Join(devRoot, want) {
+			t.Errorf("DeviceForVolume(%s) = %q, want the device %q", volumeID, devicePath, want)
+		}
+	}
+}
+
+func TestDeviceForVolumeNamesTheVolume(t *testing.T) {
+	fakeNode(t)
+
+	_, err := DeviceForVolume("106486781")
+	if err == nil {
+		t.Fatal("DeviceForVolume() = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "106486781") {
+		t.Errorf("error %q does not mention volume 106486781", err)
 	}
 }

--- a/internal/volumes/mount.go
+++ b/internal/volumes/mount.go
@@ -163,8 +163,9 @@ func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, devi
 	return s.mounter.FormatAndMountSensitiveWithFormatOptions(devicePath, targetPath, opts.FSType, mountOptions, opts.Additional, formatOptions)
 }
 
-// waitDeviceReady ensures the device at devicePath exists. This is done by ensuring a stat
-// syscall returns no error.
+// waitDeviceReady ensures the device at devicePath exists and belongs to the volume named
+// in the path. Existence is checked via stat, otherwise `blkid` might return exit code 2,
+// which is the same exit code as for an unformatted device.
 func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath string) error {
 	const maxRetries = 7
 	backoffFunc := hcloud.ExponentialBackoffWithOpts(hcloud.ExponentialBackoffOpts{
@@ -174,26 +175,38 @@ func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath stri
 	})
 
 	var err error
-	for i := range maxRetries {
+	for attempt := range maxRetries {
+		logger := s.logger.With(
+			"device-path", devicePath,
+			"attempt", attempt+1,
+			"max-attempts", maxRetries,
+		)
+
 		var stat unix.Stat_t
-		err = unix.Stat(devicePath, &stat)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, unix.ENOENT) {
+		switch err = unix.Stat(devicePath, &stat); {
+		case err == nil:
+			if err = VerifyDeviceIdentity(devicePath); err == nil {
+				return nil
+			}
+			if errors.Is(err, errDeviceMismatch) {
+				logger.Warn("device path still resolves to another volume, waiting for udev", "error", err)
+			} else {
+				logger.Warn("device identity could not be verified, refusing to mount", "error", err)
+			}
+		case errors.Is(err, unix.ENOENT):
+			logger.Debug("device path does not exist yet, waiting for the volume to attach")
+		default:
 			return err
 		}
 
-		s.logger.Debug("device not ready yet: stat syscall returned ENOENT", "devicePath", devicePath)
-
-		if i == maxRetries-1 {
+		if attempt == maxRetries-1 {
 			break
 		}
 
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("waiting for device %s: %w", devicePath, ctx.Err())
-		case <-time.After(backoffFunc(i)):
+		case <-time.After(backoffFunc(attempt)):
 		}
 	}
 

--- a/internal/volumes/mount.go
+++ b/internal/volumes/mount.go
@@ -36,7 +36,9 @@ type MountOpts struct {
 
 // MountService mounts volumes.
 type MountService interface {
-	Publish(ctx context.Context, targetPath string, devicePath string, opts MountOpts) error
+	// Publish mounts the volume with the passed ID at targetPath. The device holding the
+	// volume is looked up on the node, see DeviceForVolume.
+	Publish(ctx context.Context, targetPath string, volumeID string, opts MountOpts) error
 	Unpublish(ctx context.Context, targetPath string) error
 	PathExists(path string) (bool, error)
 }
@@ -59,11 +61,12 @@ func NewLinuxMountService(logger *slog.Logger) *LinuxMountService {
 	}
 }
 
-func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, devicePath string, opts MountOpts) error {
-	// Ensure device is ready via stat syscall. Otherwise, `blkid` might return
-	// exit code 2, which is the same exit code as for an unformatted device.
-	if err := s.waitDeviceReady(ctx, devicePath); err != nil {
-		return fmt.Errorf("device %q not ready: %w", devicePath, err)
+func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, volumeID string, opts MountOpts) error {
+	// Find the device holding the volume, and wait for it in case the attachment has not
+	// reached the node yet.
+	devicePath, err := s.waitDeviceReady(ctx, volumeID)
+	if err != nil {
+		return fmt.Errorf("device of volume %s not ready: %w", volumeID, err)
 	}
 
 	isMountPoint, err := s.mounter.IsMountPoint(targetPath)
@@ -115,7 +118,7 @@ func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, devi
 		if err != nil {
 			return fmt.Errorf("unable to detect existing disk format of %s: %w", devicePath, err)
 		}
-		luksDeviceName := GenerateLUKSDeviceName(devicePath)
+		luksDeviceName := GenerateLUKSDeviceName(VolumeDevicePath(volumeID))
 		if existingFSType == "" {
 			if opts.Readonly {
 				return fmt.Errorf("cannot publish unformatted disk %s in read-only mode", devicePath)
@@ -135,6 +138,7 @@ func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, devi
 
 	s.logger.Info(
 		"publishing volume",
+		"volume-id", volumeID,
 		"target-path", targetPath,
 		"device-path", devicePath,
 		"fs-type", opts.FSType,
@@ -163,10 +167,7 @@ func (s *LinuxMountService) Publish(ctx context.Context, targetPath string, devi
 	return s.mounter.FormatAndMountSensitiveWithFormatOptions(devicePath, targetPath, opts.FSType, mountOptions, opts.Additional, formatOptions)
 }
 
-// waitDeviceReady ensures the device at devicePath exists and belongs to the volume named
-// in the path. Existence is checked via stat, otherwise `blkid` might return exit code 2,
-// which is the same exit code as for an unformatted device.
-func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath string) error {
+func (s *LinuxMountService) waitDeviceReady(ctx context.Context, volumeID string) (string, error) {
 	const maxRetries = 7
 	backoffFunc := hcloud.ExponentialBackoffWithOpts(hcloud.ExponentialBackoffOpts{
 		Base:       time.Millisecond * 50,
@@ -177,26 +178,31 @@ func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath stri
 	var err error
 	for attempt := range maxRetries {
 		logger := s.logger.With(
-			"device-path", devicePath,
+			"volume-id", volumeID,
 			"attempt", attempt+1,
 			"max-attempts", maxRetries,
 		)
 
-		var stat unix.Stat_t
-		switch err = unix.Stat(devicePath, &stat); {
+		var devicePath string
+		switch devicePath, err = DeviceForVolume(volumeID); {
 		case err == nil:
-			if err = VerifyDeviceIdentity(devicePath); err == nil {
-				return nil
+			var stat unix.Stat_t
+			err = unix.Stat(devicePath, &stat)
+			if err == nil {
+				logger.Debug("found device of volume", "device-path", devicePath)
+				return devicePath, nil
 			}
-			if errors.Is(err, errDeviceMismatch) {
-				logger.Warn("device path still resolves to another volume, waiting for udev", "error", err)
-			} else {
-				logger.Warn("device identity could not be verified, refusing to mount", "error", err)
+			if !errors.Is(err, unix.ENOENT) {
+				return "", err
 			}
-		case errors.Is(err, unix.ENOENT):
-			logger.Debug("device path does not exist yet, waiting for the volume to attach")
+
+			logger.Debug("device node does not exist yet, waiting for devtmpfs", "device-path", devicePath)
+		case errors.Is(err, errDeviceNotFound):
+			logger.Debug("no device reports the volume yet, waiting for the volume to attach")
 		default:
-			return err
+			// Anything else, an unreadable sysfs or two devices claiming the volume, is
+			// not going to resolve itself.
+			return "", err
 		}
 
 		if attempt == maxRetries-1 {
@@ -205,12 +211,12 @@ func (s *LinuxMountService) waitDeviceReady(ctx context.Context, devicePath stri
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("waiting for device %s: %w", devicePath, ctx.Err())
+			return "", fmt.Errorf("waiting for the device of volume %s: %w", volumeID, ctx.Err())
 		case <-time.After(backoffFunc(attempt)):
 		}
 	}
 
-	return err
+	return "", err
 }
 
 func (s *LinuxMountService) Unpublish(ctx context.Context, targetPath string) error {

--- a/internal/volumes/mount_test.go
+++ b/internal/volumes/mount_test.go
@@ -1,3 +1,72 @@
 package volumes
 
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
 var _ MountService = (*LinuxMountService)(nil)
+
+// TestPublishRejectsAliasedDevice covers a stale by-id symlink resolving to another
+// volume's device. Without the identity check, Publish mounts it, or formats it when
+// blkid finds no filesystem, destroying its data (#1346).
+func TestPublishRejectsAliasedDevice(t *testing.T) {
+	sysRoot := fakeSysClassBlock(t)
+	link, byIDPrefix := fakeByID(t)
+
+	// The device of volume 106478890, holding data blkid does not recognise.
+	writeVPD(t, sysRoot, "sdc", vpdPage(t, "106478890"))
+	payload := bytes.Repeat([]byte("data-of-volume-106478890."), 40)
+
+	// udev has not caught up: the by-id link of volume 106486781 still points at it.
+	requestedPath := link("106486781", "sdc")
+	deviceOfOtherVolume, err := filepath.EvalSymlinks(requestedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(deviceOfOtherVolume, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if requestedPath != byIDPrefix+"106486781" {
+		t.Fatalf("fixture path %q does not carry the volume ID", requestedPath)
+	}
+
+	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
+
+	err = s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), requestedPath, MountOpts{})
+	if !errors.Is(err, errDeviceMismatch) {
+		t.Fatalf("Publish(%s) = %v, want %v: it mounted the device holding volume 106478890 "+
+			"after being asked for volume 106486781", requestedPath, err, errDeviceMismatch)
+	}
+
+	after, err := os.ReadFile(deviceOfOtherVolume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(payload, after) {
+		t.Fatal("volume 106478890's data was modified while refusing to publish volume 106486781")
+	}
+}
+
+// TestPublishRejectsUnverifiableDevice covers a device whose serial cannot be read. The
+// identity check is fail-closed, so Publish has to refuse rather than mount blind.
+func TestPublishRejectsUnverifiableDevice(t *testing.T) {
+	fakeSysClassBlock(t)
+	link, _ := fakeByID(t)
+
+	// No vpd_pg80 is written for sdc, so its serial is unknown.
+	requestedPath := link("106486781", "sdc")
+
+	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
+
+	err := s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), requestedPath, MountOpts{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Publish(%s) = %v, want %v", requestedPath, err, os.ErrNotExist)
+	}
+}

--- a/internal/volumes/mount_test.go
+++ b/internal/volumes/mount_test.go
@@ -12,37 +12,42 @@ import (
 
 var _ MountService = (*LinuxMountService)(nil)
 
-// TestPublishRejectsAliasedDevice covers a stale by-id symlink resolving to another
-// volume's device. Without the identity check, Publish mounts it, or formats it when
-// blkid finds no filesystem, destroying its data (#1346).
-func TestPublishRejectsAliasedDevice(t *testing.T) {
-	sysRoot := fakeSysClassBlock(t)
-	link, byIDPrefix := fakeByID(t)
+func TestWaitDeviceReadyPicksTheDeviceOfTheVolume(t *testing.T) {
+	attach, devRoot := fakeNode(t)
+
+	attach("sdc", vpdPage(t, "106478890"))
+	attach("sdd", vpdPage(t, "106486781"))
+
+	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
+
+	devicePath, err := s.waitDeviceReady(context.Background(), "106486781")
+	if err != nil {
+		t.Fatalf("waitDeviceReady() = %v, want the device of volume 106486781", err)
+	}
+	if want := filepath.Join(devRoot, "sdd"); devicePath != want {
+		t.Errorf("waitDeviceReady() = %q, want %q", devicePath, want)
+	}
+}
+
+func TestPublishRefusesWithoutAnIdentifiedDevice(t *testing.T) {
+	attach, _ := fakeNode(t)
 
 	// The device of volume 106478890, holding data blkid does not recognise.
-	writeVPD(t, sysRoot, "sdc", vpdPage(t, "106478890"))
+	deviceOfOtherVolume := attach("sdc", vpdPage(t, "106478890"))
 	payload := bytes.Repeat([]byte("data-of-volume-106478890."), 40)
-
-	// udev has not caught up: the by-id link of volume 106486781 still points at it.
-	requestedPath := link("106486781", "sdc")
-	deviceOfOtherVolume, err := filepath.EvalSymlinks(requestedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 	if err := os.WriteFile(deviceOfOtherVolume, payload, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if requestedPath != byIDPrefix+"106486781" {
-		t.Fatalf("fixture path %q does not carry the volume ID", requestedPath)
-	}
+	// A device whose serial can not be read is not an identified device either.
+	attach("sdd", nil)
 
 	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
 
-	err = s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), requestedPath, MountOpts{})
-	if !errors.Is(err, errDeviceMismatch) {
-		t.Fatalf("Publish(%s) = %v, want %v: it mounted the device holding volume 106478890 "+
-			"after being asked for volume 106486781", requestedPath, err, errDeviceMismatch)
+	err := s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), "106486781", MountOpts{})
+	if !errors.Is(err, errDeviceNotFound) {
+		t.Fatalf("Publish() = %v, want %v: it mounted a device after being asked for a volume "+
+			"no device reports", err, errDeviceNotFound)
 	}
 
 	after, err := os.ReadFile(deviceOfOtherVolume)
@@ -54,19 +59,46 @@ func TestPublishRejectsAliasedDevice(t *testing.T) {
 	}
 }
 
-// TestPublishRejectsUnverifiableDevice covers a device whose serial cannot be read. The
-// identity check is fail-closed, so Publish has to refuse rather than mount blind.
-func TestPublishRejectsUnverifiableDevice(t *testing.T) {
-	fakeSysClassBlock(t)
-	link, _ := fakeByID(t)
+func TestPublishRefusesAmbiguousDevice(t *testing.T) {
+	attach, _ := fakeNode(t)
 
-	// No vpd_pg80 is written for sdc, so its serial is unknown.
-	requestedPath := link("106486781", "sdc")
+	attach("sdc", vpdPage(t, "106486781"))
+	attach("sdd", vpdPage(t, "106486781"))
 
 	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
 
-	err := s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), requestedPath, MountOpts{})
+	err := s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), "106486781", MountOpts{})
+	if !errors.Is(err, errAmbiguousDevice) {
+		t.Fatalf("Publish() = %v, want %v", err, errAmbiguousDevice)
+	}
+}
+
+func TestPublishRefusesWhenTheDeviceNodeIsMissing(t *testing.T) {
+	_, devRoot := fakeNode(t)
+
+	writeVPD(t, sysClassBlockPath, "sdc", vpdPage(t, "106486781"))
+
+	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
+
+	err := s.Publish(context.Background(), filepath.Join(t.TempDir(), "mount"), "106486781", MountOpts{})
 	if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("Publish(%s) = %v, want %v", requestedPath, err, os.ErrNotExist)
+		t.Fatalf("Publish() = %v, want %v", err, os.ErrNotExist)
+	}
+	if _, err := os.Stat(filepath.Join(devRoot, "sdc")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fixture created a device node: %v", err)
+	}
+}
+
+func TestPublishStopsWhenTheContextIsCancelled(t *testing.T) {
+	fakeNode(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s := NewLinuxMountService(slog.New(slog.DiscardHandler))
+
+	err := s.Publish(ctx, filepath.Join(t.TempDir(), "mount"), "106486781", MountOpts{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Publish() = %v, want %v", err, context.Canceled)
 	}
 }

--- a/test/integration/cryptsetup_test.go
+++ b/test/integration/cryptsetup_test.go
@@ -18,7 +18,7 @@ func TestCryptSetup(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cryptSetup := volumes.NewCryptSetup(logger)
 	name := "fake"
-	device, err := createFakeDevice(name, 32)
+	device, _, err := createFakeDevice(name, 32)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -71,47 +71,60 @@ func runTestInDockerImage(t *testing.T, privileged bool) bool { //nolint:unparam
 const deviceFixtureVolumeIDBase = 100000000
 
 var (
-	deviceFixtureByIDPrefix    string
 	deviceFixtureSysClassBlock string
 	deviceFixtureVolumeIDs     atomic.Int64
 )
 
+// setupDeviceFixtures points the device lookup at directories the tests can write. A fake
+// device is a file: it has no SCSI serial for the driver to find it by, and sysfs, where
+// the serial would be, is not writable. The tests report one per fake device instead, so
+// that publishing takes the same path it takes on a node.
 func setupDeviceFixtures() error {
 	root, err := os.MkdirTemp(os.TempDir(), "csi-driver-devices")
 	if err != nil {
 		return err
 	}
 
-	deviceFixtureByIDPrefix = filepath.Join(root, "by-id", "scsi-0HC_Volume_")
 	deviceFixtureSysClassBlock = filepath.Join(root, "sys", "class", "block")
-
-	if err := os.MkdirAll(filepath.Dir(deviceFixtureByIDPrefix), 0o750); err != nil {
-		return err
-	}
 	if err := os.MkdirAll(deviceFixtureSysClassBlock, 0o750); err != nil {
 		return err
 	}
 
-	volumes.SetDeviceIdentityPaths(deviceFixtureByIDPrefix, deviceFixtureSysClassBlock)
+	// The fake devices are files at the root of the container filesystem, so that is
+	// where the driver has to look for the device the fixture sysfs reports.
+	volumes.SetDeviceIdentityPaths("/", deviceFixtureSysClassBlock)
 
 	return nil
 }
 
-func createFakeDevice(name string, megabytes int) (string, error) {
-	path := "/dev-" + name
-	if _, err := os.Create(path); err != nil {
-		return "", err
+// createFakeDevice creates a file standing in for a block device, and the sysfs entry
+// reporting the serial of the volume it holds. It returns the device path and that volume
+// ID: the driver is asked for the volume and finds the device by its serial, the same way
+// it does on a node.
+func createFakeDevice(name string, megabytes int) (devicePath string, volumeID string, err error) {
+	devicePath = "/dev-" + name
+	if _, err := os.Create(devicePath); err != nil {
+		return "", "", err
 	}
-	if _, err := runCmd("dd", "if=/dev/zero", "of="+path, "bs=1M", "count="+strconv.Itoa(megabytes)); err != nil {
-		return "", err
+	if _, err := runCmd("dd", "if=/dev/zero", "of="+devicePath, "bs=1M", "count="+strconv.Itoa(megabytes)); err != nil {
+		return "", "", err
 	}
-	return linkFakeDeviceByID(path)
+
+	volumeID, err = reportFakeDeviceSerial(filepath.Base(devicePath))
+	if err != nil {
+		return "", "", err
+	}
+
+	return devicePath, volumeID, nil
 }
 
-func linkFakeDeviceByID(devicePath string) (string, error) {
+// reportFakeDeviceSerial makes the fake device report the serial of a volume, the way the
+// kernel does for a SCSI disk. device is the name of the device file, as it appears in
+// sysfs.
+func reportFakeDeviceSerial(device string) (string, error) {
 	volumeID := strconv.FormatInt(deviceFixtureVolumeIDBase+deviceFixtureVolumeIDs.Add(1), 10)
 
-	vpdDir := filepath.Join(deviceFixtureSysClassBlock, filepath.Base(devicePath), "device")
+	vpdDir := filepath.Join(deviceFixtureSysClassBlock, device, "device")
 	if err := os.MkdirAll(vpdDir, 0o750); err != nil {
 		return "", err
 	}
@@ -119,14 +132,11 @@ func linkFakeDeviceByID(devicePath string) (string, error) {
 		return "", err
 	}
 
-	byIDPath := deviceFixtureByIDPrefix + volumeID
-	if err := os.Symlink(devicePath, byIDPath); err != nil {
-		return "", err
-	}
-
-	return byIDPath, nil
+	return volumeID, nil
 }
 
+// vpdPage lays out the bytes the kernel exposes as vpd_pg80 for a SCSI disk: a 4 byte
+// header whose last two bytes hold the length of the serial that follows.
 func vpdPage(serial string) []byte {
 	page := make([]byte, 4, 4+len(serial))
 	page[1] = 0x80

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -3,24 +3,33 @@
 package integration
 
 import (
+	"encoding/binary"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"k8s.io/mount-utils"
+
+	"github.com/hetznercloud/csi-driver/internal/volumes"
 )
 
-const testImageName = "hcloud-csi-driver-integrationtests"
-const testImageEnvironmentVariable = "HCLOUD_CSI_DRIVER_INTEGRATIONTESTS"
+const (
+	testImageName                = "hcloud-csi-driver-integrationtests"
+	testImageEnvironmentVariable = "HCLOUD_CSI_DRIVER_INTEGRATIONTESTS"
+)
 
 func TestMain(t *testing.M) {
 	if os.Getenv(testImageEnvironmentVariable) != "true" {
 		if err := prepareDockerImage(); err != nil {
 			log.Fatal(err)
 		}
+	} else if err := setupDeviceFixtures(); err != nil {
+		log.Fatal(err)
 	}
 
 	os.Exit(t.Run())
@@ -59,6 +68,35 @@ func runTestInDockerImage(t *testing.T, privileged bool) bool { //nolint:unparam
 	return false
 }
 
+const deviceFixtureVolumeIDBase = 100000000
+
+var (
+	deviceFixtureByIDPrefix    string
+	deviceFixtureSysClassBlock string
+	deviceFixtureVolumeIDs     atomic.Int64
+)
+
+func setupDeviceFixtures() error {
+	root, err := os.MkdirTemp(os.TempDir(), "csi-driver-devices")
+	if err != nil {
+		return err
+	}
+
+	deviceFixtureByIDPrefix = filepath.Join(root, "by-id", "scsi-0HC_Volume_")
+	deviceFixtureSysClassBlock = filepath.Join(root, "sys", "class", "block")
+
+	if err := os.MkdirAll(filepath.Dir(deviceFixtureByIDPrefix), 0o750); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(deviceFixtureSysClassBlock, 0o750); err != nil {
+		return err
+	}
+
+	volumes.SetDeviceIdentityPaths(deviceFixtureByIDPrefix, deviceFixtureSysClassBlock)
+
+	return nil
+}
+
 func createFakeDevice(name string, megabytes int) (string, error) {
 	path := "/dev-" + name
 	if _, err := os.Create(path); err != nil {
@@ -67,7 +105,34 @@ func createFakeDevice(name string, megabytes int) (string, error) {
 	if _, err := runCmd("dd", "if=/dev/zero", "of="+path, "bs=1M", "count="+strconv.Itoa(megabytes)); err != nil {
 		return "", err
 	}
-	return path, nil
+	return linkFakeDeviceByID(path)
+}
+
+func linkFakeDeviceByID(devicePath string) (string, error) {
+	volumeID := strconv.FormatInt(deviceFixtureVolumeIDBase+deviceFixtureVolumeIDs.Add(1), 10)
+
+	vpdDir := filepath.Join(deviceFixtureSysClassBlock, filepath.Base(devicePath), "device")
+	if err := os.MkdirAll(vpdDir, 0o750); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(vpdDir, "vpd_pg80"), vpdPage(volumeID), 0o600); err != nil {
+		return "", err
+	}
+
+	byIDPath := deviceFixtureByIDPrefix + volumeID
+	if err := os.Symlink(devicePath, byIDPath); err != nil {
+		return "", err
+	}
+
+	return byIDPath, nil
+}
+
+func vpdPage(serial string) []byte {
+	page := make([]byte, 4, 4+len(serial))
+	page[1] = 0x80
+	binary.BigEndian.PutUint16(page[2:4], uint16(len(serial))) //nolint:gosec // a volume ID is 9 digits
+
+	return append(page, serial...)
 }
 
 func increaseFakeDeviceSize(name string, megabytesToAdd int) error {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -75,10 +75,6 @@ var (
 	deviceFixtureVolumeIDs     atomic.Int64
 )
 
-// setupDeviceFixtures points the device lookup at directories the tests can write. A fake
-// device is a file: it has no SCSI serial for the driver to find it by, and sysfs, where
-// the serial would be, is not writable. The tests report one per fake device instead, so
-// that publishing takes the same path it takes on a node.
 func setupDeviceFixtures() error {
 	root, err := os.MkdirTemp(os.TempDir(), "csi-driver-devices")
 	if err != nil {
@@ -97,10 +93,6 @@ func setupDeviceFixtures() error {
 	return nil
 }
 
-// createFakeDevice creates a file standing in for a block device, and the sysfs entry
-// reporting the serial of the volume it holds. It returns the device path and that volume
-// ID: the driver is asked for the volume and finds the device by its serial, the same way
-// it does on a node.
 func createFakeDevice(name string, megabytes int) (devicePath string, volumeID string, err error) {
 	devicePath = "/dev-" + name
 	if _, err := os.Create(devicePath); err != nil {
@@ -118,9 +110,6 @@ func createFakeDevice(name string, megabytes int) (devicePath string, volumeID s
 	return devicePath, volumeID, nil
 }
 
-// reportFakeDeviceSerial makes the fake device report the serial of a volume, the way the
-// kernel does for a SCSI disk. device is the name of the device file, as it appears in
-// sysfs.
 func reportFakeDeviceSerial(device string) (string, error) {
 	volumeID := strconv.FormatInt(deviceFixtureVolumeIDBase+deviceFixtureVolumeIDs.Add(1), 10)
 

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -24,10 +24,12 @@ func TestVolumePublishUnpublish(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		mountOpts     volumes.MountOpts
-		prepare       func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error
-		expectedError error
+		name      string
+		mountOpts volumes.MountOpts
+		prepare   func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error
+		// expectedError is passed the device path, which carries the ID of the volume the
+		// test got and is therefore only known once the fake device exists.
+		expectedError func(device string) error
 	}{
 		// Block volume not formatted
 		{
@@ -50,7 +52,9 @@ func TestVolumePublishUnpublish(t *testing.T) {
 			prepare: func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error {
 				return formatDisk(mounter, device, "xfs")
 			},
-			expectedError: mount.NewMountError(mount.FilesystemMismatch, ""),
+			expectedError: func(string) error {
+				return mount.NewMountError(mount.FilesystemMismatch, "")
+			},
 		},
 		{
 			name:          "block-volume",
@@ -98,7 +102,9 @@ func TestVolumePublishUnpublish(t *testing.T) {
 			prepare: func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error {
 				return formatDisk(mounter, device, "ext4")
 			},
-			expectedError: fmt.Errorf("requested encrypted volume, but disk /dev-fake-encrypted-wrong-formatted-1 already is formatted with ext4"),
+			expectedError: func(device string) error {
+				return fmt.Errorf("requested encrypted volume, but disk %s already is formatted with ext4", device)
+			},
 		},
 	}
 
@@ -141,13 +147,18 @@ func TestVolumePublishUnpublish(t *testing.T) {
 				}
 			}()
 
+			var expectedError error
 			if test.expectedError != nil {
+				expectedError = test.expectedError(device)
+			}
+
+			if expectedError != nil {
 				if publishErr == nil {
-					t.Fatalf("expected error %q but got no error", test.expectedError.Error())
+					t.Fatalf("expected error %q but got no error", expectedError.Error())
 				}
 
 				if got, ok := publishErr.(mount.MountError); ok {
-					if expected, ok := test.expectedError.(mount.MountError); ok {
+					if expected, ok := expectedError.(mount.MountError); ok {
 						if got.Type != expected.Type {
 							t.Fatalf("Expected Mount Error %s, but got %s", expected.Type, got.Type)
 						}
@@ -155,8 +166,8 @@ func TestVolumePublishUnpublish(t *testing.T) {
 					} else {
 						t.Fatalf("Test returned MountError %s, but expected error is not of MountError", got.Type)
 					}
-				} else if test.expectedError.Error() != publishErr.Error() {
-					t.Fatal(fmt.Errorf("expected error %q but got %q", test.expectedError.Error(), publishErr.Error()))
+				} else if expectedError.Error() != publishErr.Error() {
+					t.Fatal(fmt.Errorf("expected error %q but got %q", expectedError.Error(), publishErr.Error()))
 				}
 			}
 

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -24,12 +24,10 @@ func TestVolumePublishUnpublish(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		mountOpts volumes.MountOpts
-		prepare   func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error
-		// expectedError is passed the device path, which carries the ID of the volume the
-		// test got and is therefore only known once the fake device exists.
-		expectedError func(device string) error
+		name          string
+		mountOpts     volumes.MountOpts
+		prepare       func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error
+		expectedError error
 	}{
 		// Block volume not formatted
 		{
@@ -52,9 +50,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 			prepare: func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error {
 				return formatDisk(mounter, device, "xfs")
 			},
-			expectedError: func(string) error {
-				return mount.NewMountError(mount.FilesystemMismatch, "")
-			},
+			expectedError: mount.NewMountError(mount.FilesystemMismatch, ""),
 		},
 		{
 			name:          "block-volume",
@@ -102,9 +98,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 			prepare: func(ctx context.Context, mounter *mount.SafeFormatAndMount, cs *volumes.CryptSetup, device string) error {
 				return formatDisk(mounter, device, "ext4")
 			},
-			expectedError: func(device string) error {
-				return fmt.Errorf("requested encrypted volume, but disk %s already is formatted with ext4", device)
-			},
+			expectedError: fmt.Errorf("requested encrypted volume, but disk /dev-fake-encrypted-wrong-formatted-1 already is formatted with ext4"),
 		},
 	}
 
@@ -118,7 +112,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 				Exec:      exec.New(),
 			}
 			cryptSetup := volumes.NewCryptSetup(logger)
-			device, err := createFakeDevice("fake-"+test.name, 512)
+			device, volumeID, err := createFakeDevice("fake-"+test.name, 512)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -137,7 +131,7 @@ func TestVolumePublishUnpublish(t *testing.T) {
 			// Required as FS volumes require target dir, but block volumes require
 			// target file
 			targetPath = path.Join(targetPath, "target-path")
-			publishErr := mountService.Publish(ctx, targetPath, device, test.mountOpts)
+			publishErr := mountService.Publish(ctx, targetPath, volumeID, test.mountOpts)
 			defer func() {
 				err := mountService.Unpublish(ctx, targetPath)
 				if err != nil {
@@ -147,18 +141,13 @@ func TestVolumePublishUnpublish(t *testing.T) {
 				}
 			}()
 
-			var expectedError error
 			if test.expectedError != nil {
-				expectedError = test.expectedError(device)
-			}
-
-			if expectedError != nil {
 				if publishErr == nil {
-					t.Fatalf("expected error %q but got no error", expectedError.Error())
+					t.Fatalf("expected error %q but got no error", test.expectedError.Error())
 				}
 
 				if got, ok := publishErr.(mount.MountError); ok {
-					if expected, ok := expectedError.(mount.MountError); ok {
+					if expected, ok := test.expectedError.(mount.MountError); ok {
 						if got.Type != expected.Type {
 							t.Fatalf("Expected Mount Error %s, but got %s", expected.Type, got.Type)
 						}
@@ -166,8 +155,8 @@ func TestVolumePublishUnpublish(t *testing.T) {
 					} else {
 						t.Fatalf("Test returned MountError %s, but expected error is not of MountError", got.Type)
 					}
-				} else if expectedError.Error() != publishErr.Error() {
-					t.Fatal(fmt.Errorf("expected error %q but got %q", expectedError.Error(), publishErr.Error()))
+				} else if test.expectedError.Error() != publishErr.Error() {
+					t.Fatal(fmt.Errorf("expected error %q but got %q", test.expectedError.Error(), publishErr.Error()))
 				}
 			}
 
@@ -239,7 +228,7 @@ func TestVolumeResize(t *testing.T) {
 			resizeService := volumes.NewLinuxResizeService(logger)
 			cryptSetup := volumes.NewCryptSetup(logger)
 			deviceName := "fake-" + test.name
-			device, err := createFakeDevice(deviceName, 512)
+			device, volumeID, err := createFakeDevice(deviceName, 512)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -274,7 +263,7 @@ func TestVolumeResize(t *testing.T) {
 				t.Fatal()
 			}
 
-			if err := mountService.Publish(ctx, targetPath, device, volumes.MountOpts{
+			if err := mountService.Publish(ctx, targetPath, volumeID, volumes.MountOpts{
 				EncryptionPassphrase: test.passphrase,
 			}); err != nil {
 				t.Fatal(err)
@@ -354,7 +343,7 @@ func TestDetectDiskFormat(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      exec.New(),
 			}
-			disk, err := createFakeDevice(test.name, 512)
+			disk, _, err := createFakeDevice(test.name, 512)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
The `/dev/disk/by-id` symlinks are maintained asynchronously by udev, so
after an attach that reuses a device name, the symlink of one volume can
still resolve to the block device of another.

The resolved device is now checked against the volume ID taken from the
by-id path by reading its SCSI serial from VPD page 0x80 in
`/sys/class/block/<device>/device/vpd_pg80`. A mismatch is retried
through the existing `waitDeviceReady` backoff, which is where a symlink
udev has not caught up with yet becomes correct.

The check is fail-closed: if the serial cannot be read, the volume is
not published rather than published unverified, because mounting the
wrong device destroys data while refusing to mount does not. Devices
that do not expose `vpd_pg80` are therefore no longer published.

Fixes #1346
