### PR TITLE
fix: panic in ListVolumes when the project has volumes

### DIFF
--- a/internal/volsrv/volume.go
+++ b/internal/volsrv/volume.go
@@ -33,8 +33,8 @@ func (s *VolumeService) All(ctx context.Context) ([]*csi.Volume, error) {
 	}
 
 	volumes := make([]*csi.Volume, 0, len(hcloudVolumes))
-	for i, hcloudVolume := range hcloudVolumes {
-		volumes[i] = toDomainVolume(hcloudVolume)
+	for _, hcloudVolume := range hcloudVolumes {
+		volumes = append(volumes, toDomainVolume(hcloudVolume))
 	}
 	return volumes, nil
 }

--- a/internal/volsrv/volume_test.go
+++ b/internal/volsrv/volume_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/csi-driver/internal/csi"
 	"github.com/hetznercloud/csi-driver/internal/volumes"
@@ -89,5 +90,61 @@ func TestResize(t *testing.T) {
 			err := volumeService.Resize(context.Background(), &csi.Volume{ID: 1}, 10)
 			assert.Equal(t, volumes.ErrVolumeSizeAlreadyReached, err)
 		})
+	})
+}
+
+func TestAll(t *testing.T) {
+	t.Run("with volumes", func(t *testing.T) {
+		volumeService, cleanup := makeTestVolumeService(t, []mockutil.Request{
+			{
+				Method: "GET", Path: "/volumes?page=1&per_page=50",
+				Status: 200,
+				JSON: schema.VolumeListResponse{
+					Volumes: []schema.Volume{
+						{
+							ID: 1, Name: "pvc-123", Size: 10,
+							Location:    schema.Location{Name: "hel1"},
+							LinuxDevice: "/dev/disk/by-id/scsi-0HC_Volume_1",
+							Server:      new(int64(42)),
+						},
+						{
+							ID: 2, Name: "pvc-456", Size: 20,
+							Location: schema.Location{Name: "fsn1"},
+						},
+					},
+				},
+			},
+		})
+		defer cleanup()
+
+		vols, err := volumeService.All(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []*csi.Volume{
+			{
+				ID: 1, Name: "pvc-123", Size: 10,
+				Location:    "hel1",
+				LinuxDevice: "/dev/disk/by-id/scsi-0HC_Volume_1",
+				Server:      &csi.Server{ID: 42},
+			},
+			{
+				ID: 2, Name: "pvc-456", Size: 20,
+				Location: "fsn1",
+			},
+		}, vols)
+	})
+
+	t.Run("without volumes", func(t *testing.T) {
+		volumeService, cleanup := makeTestVolumeService(t, []mockutil.Request{
+			{
+				Method: "GET", Path: "/volumes?page=1&per_page=50",
+				Status: 200,
+				JSON:   schema.VolumeListResponse{},
+			},
+		})
+		defer cleanup()
+
+		vols, err := volumeService.All(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, vols)
 	})
 }


### PR DESCRIPTION
Present since the RPC was first implemented (v2.0.0). The sanity
suite never caught it because it substitutes a fake volume service for
`volsrv`, and none of the sidecars shipped in the chart call ListVolumes.

Switch the loop to `append` so the existing preallocation stays correct, and
cover `All` with a test over a non-empty list.
