### PR TITLE
feat(chart): allow extra args on the csi-provisioner container

### DIFF
--- a/chart/.snapshots/full.yaml
+++ b/chart/.snapshots/full.yaml
@@ -618,6 +618,7 @@ spec:
             - --strict-topology
             - --leader-election
             - --leader-election-namespace=namespace-override
+            - --volume-name-prefix=pvc-mycluster
           volumeMounts:
           - name: socket-dir
             mountPath: /run/csi

--- a/chart/full-values.yaml
+++ b/chart/full-values.yaml
@@ -116,6 +116,10 @@ controller:
         memory: 45Mi
         cpu: 15m
 
+  extraArgs:
+    csiProvisioner:
+      - --volume-name-prefix=pvc-mycluster
+
   podLabels:
     pod-label: pod-label
 

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -205,6 +205,9 @@ spec:
             - --leader-election
             - --leader-election-namespace={{ include "hcloud-csi.names.namespace" . }}
             {{- end}}
+            {{- if .Values.controller.extraArgs.csiProvisioner }}
+            {{- include "hcloud-csi.tplvalues.render" (dict "value" .Values.controller.extraArgs.csiProvisioner "context" $) | nindent 12 }}
+            {{- end }}
           volumeMounts:
           - name: socket-dir
             mountPath: /run/csi

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -205,8 +205,8 @@ spec:
             - --leader-election
             - --leader-election-namespace={{ include "hcloud-csi.names.namespace" . }}
             {{- end}}
-            {{- if .Values.controller.extraArgs.csiProvisioner }}
-            {{- include "hcloud-csi.tplvalues.render" (dict "value" .Values.controller.extraArgs.csiProvisioner "context" $) | nindent 12 }}
+            {{- if (.Values.controller.extraArgs).csiProvisioner }}
+            {{- include "hcloud-csi.tplvalues.render" (dict "value" (.Values.controller.extraArgs).csiProvisioner "context" $) | nindent 12 }}
             {{- end }}
           volumeMounts:
           - name: socket-dir

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -38,6 +38,18 @@
           "properties": {},
           "type": "object"
         },
+        "extraArgs": {
+          "additionalProperties": false,
+          "properties": {
+            "csiProvisioner": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
         "extraEnvVars": {
           "type": "array"
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -268,6 +268,15 @@ controller:
       limits: {}
       requests: {}
 
+  ## @param controller.extraArgs.csiProvisioner Array with extra arguments for the csi-provisioner container
+  ## e.g:
+  ## extraArgs:
+  ##   csiProvisioner:
+  ##     - --volume-name-prefix=pvc-mycluster
+  ##
+  extraArgs:
+    csiProvisioner: []
+
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param controller.podSecurityContext.enabled Enabled controller pods' Security Context


### PR DESCRIPTION
## Motivation

The chart hardcodes the csi-provisioner args, so flags like `--volume-name-prefix` cannot be set through values. Cloud volumes are always named `pvc-<uuid>`, with no way to tell which cluster they belong to.

This adds `controller.extraArgs.csiProvisioner` (default `[]`), rendered with the chart's `extraEnvVars` pattern:

```yaml
controller:
  extraArgs:
    csiProvisioner:
      - --volume-name-prefix=pvc-mycluster
```